### PR TITLE
handle infinite boundary condition in Gutzwiller projections for Abrikosov fermions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### New features
 
+* Gutzwiller projections {func}`temfpy.gutzwiller.abrikosov` and {func}`temfpy.gutzwiller.abrikosov_ph` allow targeting different virtual charge/parity sectors, which may give access to different topological sectors. [#18](https://github.com/temfpy/temfpy/pull/18)
+
 ### Bug fixes
+
+* Gutzwiller projections {func}`temfpy.gutzwiller.abrikosov` and {func}`temfpy.gutzwiller.abrikosov_ph` now handle most infinite fermion MPS correctly. [#18](https://github.com/temfpy/temfpy/pull/18)
 
 ## TeMFpy 0.2.1 (28 January 2026)
 

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -82,7 +82,7 @@ def abrikosov(
     cutoff: float = 1e-12,
     q_left: int = 0,
 ) -> None | networks.MPS:
-    r"""Projection from Abrikosov fermions to a spin-1/2 Hilbert space for a finite MPS.
+    r"""Projection from Abrikosov fermions to a spin-1/2 Hilbert space.
 
     The input MPS must contain an even number of sites, sites :math:`2i` and
     :math:`2i+1` representing modes :math:`f_{i\uparrow}` and
@@ -120,7 +120,7 @@ def abrikosov(
     ----
         Currently,
         - no symmetry quantum numbers other than fermion number or parity can be handled.
-        - all tensors of the MPS must have trivial :attr:`~tenpy.linalg.np_conserved.Array.qtotal`
+        - only 'finite' and 'infinite' boundary conditions are supported.
     """
 
     assert (
@@ -278,8 +278,6 @@ def abrikosov_ph(
 
         - no symmetry quantum numbers other than fermion number or parity can be handled.
         - only 'finite' and 'infinite' boundary conditions are supported.
-        - all tensors of a finite MPS must have trivial :attr:`~tenpy.linalg.np_conserved.Array.qtotal`.
-        - only the last tensor of an iMPS can have non-trivial :attr:`~tenpy.linalg.np_conserved.Array.qtotal`.
     """
 
     assert (

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -133,12 +133,12 @@ def abrikosov(
         ), f"All sites must be fermionic, found: {site} at site {i}"
 
     if mps.bc == "finite":
-        assert mps.get_total_charge(True) == mps.L // 2
+        assert mps.get_total_charge(True)[0] == mps.L // 2
         if q_left != 0:
             warnings.warn(f"`q_left` must be 0 for finite MPS, ignoring {q_left = }")
             q_left = 0
     elif mps.bc == "infinite":
-        assert mps.get_total_charge() == mps.L // 2
+        assert mps.get_total_charge()[0] == mps.L // 2
     else:
         raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
 
@@ -234,6 +234,7 @@ def abrikosov_ph(
     inplace: bool = False,
     return_canonical: bool = True,
     cutoff: float = 1e-12,
+    offset: int = 0,
 ) -> None | networks.MPS:
     r"""Projection from particle-hole rotated Abrikosov fermions to a spin-1/2 Hilbert space.
 
@@ -266,6 +267,15 @@ def abrikosov_ph(
         Whether to transform the output MPS to right canonical form.
     cutoff:
         Cutoff for Schmidt values to keep in the canonical form.
+    offset:
+        If the input iMPS preserves particle number, adjusts the mapping of
+        fermion number to spin on virtual legs:
+        ``2S^z = number - offset - bond_index``
+
+        Also selects the fermion parity of virtual legs to be kept after
+        projection (also for iMPS conserving fermion parity).
+
+        Can only be specified for infinite MPS!
 
     Returns
     -------
@@ -291,34 +301,26 @@ def abrikosov_ph(
             site, networks.FermionSite
         ), f"All sites must be fermionic, found: {site} at site {i}"
 
-    # TODO: support 'segment' boundary conditions
-    assert mps.bc in [
-        "finite",
-        "infinite",
-    ], f"Only 'finite' and 'infinite' MPS are supported as boundary conditions, found '{mps.bc}'"
-
-    # TODO: allow for more general charge structure
-    parity_pn = 0
     if mps.bc == "finite":
-        assert np.all(
-            [tensor.qtotal == 0 for tensor in mps._B]
-        ), "All tensors of a finite MPS must have zero total charge"
-        parity_pn = mps._B[-1].get_leg("vR").charges[0] % 2
+        assert mps.get_total_charge(True)[0] % 2 == 0
+        if offset != 0:
+            warnings.warn(f"Cannot offset finite MPS, ignoring {offset = }")
+        offset = parity = 0
+        qtotal = None
+    elif mps.bc == "infinite":
+        qtotal = mps.get_total_charge()
+        assert qtotal[0] % 2 == 0
+        parity = offset % 2
     else:
-        assert np.all(
-            [tensor.qtotal == 0 for tensor in mps._B[:-1]]
-        ), "Except for the last, all tensors of an infinite MPS must have zero total charge"
-        parity_pn = int(mps._B[-1].qtotal[0]) % 2
-
-    error_msg = (
-        "To be able to project a MPS representing particle-hole rotated Abrikosov fermions, "
-        "the total parity of the MPS must be even."
-    )
-    assert parity_pn % 2 == 0, error_msg
+        # TODO: support 'segment' boundary conditions
+        raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
 
     if not inplace:
         mps = mps.copy()
         logger.debug(f"Deep copied MPS before Gutzwiller projection.")
+
+    # Shift all tensor charges to the end
+    mps.gauge_total_charge(qtotal=qtotal)
 
     conserved_fermion = mps.sites[0].conserve
     if conserved_fermion == "N":
@@ -346,8 +348,8 @@ def abrikosov_ph(
         # Remove LegPipe structure
         B.legs[B.get_leg_index("p")] = B.get_leg("p").to_LegCharge()
 
-        mask_vL = parity_mask(B.get_leg("vL"))
-        mask_vR = parity_mask(B.get_leg("vR"))
+        mask_vL = parity_mask(B.get_leg("vL"), parity)
+        mask_vR = parity_mask(B.get_leg("vR"), parity)
 
         # Change the occupation number leg charges to spin charges
         # --------------------------------------------------------
@@ -366,10 +368,10 @@ def abrikosov_ph(
             leg_p.charges = spin_leg.charges
 
             leg_vL.chinfo = chinfo_s
-            leg_vL.charges -= idx
+            leg_vL.charges -= offset + idx
 
             leg_vR.chinfo = chinfo_s
-            leg_vR.charges -= idx + 1
+            leg_vR.charges -= offset + idx + 1
 
         else:  # None
             B = B.drop_charge(charge="parity_N", chinfo=chinfo_s)

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -100,7 +100,8 @@ def abrikosov(
     Parameters
     ----------
     mps:
-        Finite MPS representing the wave function to be projected.
+        MPS representing the wave function to be projected.
+
         Must be of even length and every site must be an instance
         of :class:`~tenpy.networks.site.FermionSite`.
     inplace:
@@ -251,6 +252,7 @@ def abrikosov_ph(
     ----------
     mps:
         MPS representing the wave function to be projected.
+        
         Must be of even length and every site must be an instance
         of :class:`~tenpy.networks.site.FermionSite`.
     inplace:

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -80,7 +80,7 @@ def abrikosov(
     inplace: bool = False,
     return_canonical: bool = True,
     cutoff: float = 1e-12,
-    q_left: int = 0,
+    q_left: None | int = 0,
 ) -> None | networks.MPS:
     r"""Projection from Abrikosov fermions to a spin-1/2 Hilbert space.
 
@@ -112,6 +112,8 @@ def abrikosov(
         Cutoff for Schmidt values to keep in the canonical form.
     q_left:
         Fermion number/parity sector on the leftmost leg to be kept (only for iMPS).
+        Has to be a charge sector contained within :attr:`~tenpy.linalg.charges.LegCharge.charges` 
+        of the leftmost virtual leg of the iMPS unit cell.
 
     Returns
     -------
@@ -147,7 +149,7 @@ def abrikosov(
     def check_charge(q: np.ndarray):
         q = q[0]
         target = mps.L // 2
-        err = f"Total charge must match number of spin sites, {target}, got {q}"
+        err = f"Total charge must match number of spin sites. Got {q}, expected {target}"
         if conserved_fermion == "N":
             assert q == target, err
         else:  # parity
@@ -156,11 +158,19 @@ def abrikosov(
     if mps.bc == "finite":
         check_charge(mps.get_total_charge(True))
         qtotal = None
-        if q_left != 0:
-            warn(f"`q_left` must be 0 for finite MPS, ignoring {q_left = }")
+        if q_left not in (None, 0):
+            warn(f"`q_left` must be 0 for finite MPS, got {q_left = }, setting it to 0.")
         q_left = 0
     elif mps.bc == "infinite":
         check_charge(qtotal := mps.get_total_charge())
+        if q_left is None:
+            raise ValueError("Must specify `q_left` for infinite MPS.")
+        if q_left not in mps._B[0].get_leg("vL").charge_sectors()[:,0]:
+            raise ValueError(
+                f"`q_left` must be a charge sector of the leftmost virtual leg, got {q_left = }, "
+                f"valid sectors are {mps._B[0].get_leg('vL').charge_sectors()}"
+            )
+
     else:
         raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
 

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -156,18 +156,18 @@ def abrikosov(
         assert vL_leg.ind_len == 1, "Ends of finite MPS must have chi = 1"
         charges = vL_leg.charges.copy()
         charges[:, 0] = 0
-        vL_leg.charges = charges
+        vL_leg.charges = mps.chinfo.make_valid(charges)
         # want charge L/2 on the right
         assert vR_leg.ind_len == 1, "Ends of finite MPS must have chi = 1"
         charges = vR_leg.charges.copy()
         charges[:, 0] = mps.L // 2
-        vR_leg.charges = charges
+        vR_leg.charges = mps.chinfo.make_valid(charges)
     elif mps.bc == "infinite":
         assert np.all(vL_leg.charges == vR_leg.charges), "Two ends of iMPS incompatible"
         # want to subtract q_left from both left and right end
         charges = vL_leg.charges.copy()
         charges[:, 0] -= q_left
-        vL_leg.charges = vR_leg.charges = charges
+        vL_leg.charges = vR_leg.charges = mps.chinfo.make_valid(charges)
     mps.gauge_total_charge(vL_leg=vL_leg, vR_leg=vR_leg)
 
     conserved_fermion = mps.sites[0].conserve

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -111,7 +111,9 @@ def abrikosov(
     cutoff:
         Cutoff for Schmidt values to keep in the canonical form.
     q_left:
-        Fermion number/parity sector on the leftmost leg to be kept (only for iMPS).
+        For infinite MPS **only**, determines which fermion number/parity sector
+        of the leftmost virtual leg to keep.
+        
         Has to be a charge sector contained within :attr:`~tenpy.linalg.charges.LegCharge.charges` 
         of the leftmost virtual leg of the iMPS unit cell.
 

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -80,7 +80,7 @@ def abrikosov(
     inplace: bool = False,
     return_canonical: bool = True,
     cutoff: float = 1e-12,
-    q_left: None | int = 0,
+    q_left: None | int = None,
 ) -> None | networks.MPS:
     r"""Projection from Abrikosov fermions to a spin-1/2 Hilbert space.
 

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -73,12 +73,13 @@ def number_mask(leg: npc.charges.LegCharge, n: int) -> np.ndarray:
 # ----------------------
 
 
-def abrikosov_finite(
+def abrikosov(
     mps: networks.MPS,
     *,
     inplace: bool = False,
     return_canonical: bool = True,
     cutoff: float = 1e-12,
+    q_left: int = 0,
 ) -> None | networks.MPS:
     r"""Projection from Abrikosov fermions to a spin-1/2 Hilbert space for a finite MPS.
 
@@ -107,14 +108,16 @@ def abrikosov_finite(
         Whether to transform the output MPS to right canonical form.
     cutoff:
         Cutoff for Schmidt values to keep in the canonical form.
+    q_left:
+        Fermion number/parity sector on the leftmost leg to be kept (only for iMPS).
 
     Returns
     -------
         The Gutzwiller projected ``mps``, if ``inplace`` is :obj:`False`.
-    
+
     Note
     ----
-        Currently, 
+        Currently,
         - no symmetry quantum numbers other than fermion number or parity can be handled.
         - all tensors of the MPS must have trivial :attr:`~tenpy.linalg.np_conserved.Array.qtotal`
     """
@@ -128,19 +131,44 @@ def abrikosov_finite(
         assert isinstance(
             site, networks.FermionSite
         ), f"All sites must be fermionic, found: {site} at site {i}"
-    
-    assert (
-        mps.bc == "finite"
-    ), f"Only 'finite' MPS are supported as boundary conditions, found '{mps.bc}'"
 
-    # TODO: allow for more general charge structure
-    assert (
-        np.all([tensor.qtotal == 0 for tensor in mps._B])
-    ), "All tensors of a finite MPS must have zero total charge"
+    if mps.bc == "finite":
+        assert mps.get_total_charge(True) == mps.L // 2
+        if q_left != 0:
+            warnings.warn(f"`q_left` must be 0 for finite MPS, ignoring {q_left = }")
+            q_left = 0
+    elif mps.bc == "infinite":
+        assert mps.get_total_charge() == mps.L // 2
+    else:
+        raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
 
     if not inplace:
         mps = mps.copy()
         logger.debug(f"Deep copied MPS before Gutzwiller projection.")
+
+    # normalise legs and tensor charges
+    vL_leg: npc.LegCharge = mps._B[0].get_leg("vL").copy()
+    vR_leg: npc.LegCharge = mps._B[-1].get_leg("vR").copy()
+    assert vL_leg.qconj == 1
+    assert vR_leg.qconj == -1
+    if mps.bc == "finite":
+        # want charge 0 on the left, and no tensor charges
+        assert vL_leg.ind_len == 1, "Ends of finite MPS must have chi = 1"
+        charges = vL_leg.charges.copy()
+        charges[:, 0] = 0
+        vL_leg.charges = charges
+        # want charge L/2 on the right
+        assert vR_leg.ind_len == 1, "Ends of finite MPS must have chi = 1"
+        charges = vR_leg.charges.copy()
+        charges[:, 0] = mps.L // 2
+        vR_leg.charges = charges
+    elif mps.bc == "infinite":
+        assert np.all(vL_leg.charges == vR_leg.charges), "Two ends of iMPS incompatible"
+        # want to subtract q_left from both left and right end
+        charges = vL_leg.charges.copy()
+        charges[:, 0] -= q_left
+        vL_leg.charges = vR_leg.charges = charges
+    mps.gauge_total_charge(vL_leg=vL_leg, vR_leg=vR_leg)
 
     conserved_fermion = mps.sites[0].conserve
     if conserved_fermion == "N":
@@ -149,7 +177,7 @@ def abrikosov_finite(
         mask = parity_mask
     else:
         raise ValueError(
-            f"FermionSite must conserve either 'N' or 'parity', found {conserved_fermion}"
+            f"FermionSite must conserve either 'N' or 'parity', found {conserved_fermion!r}"
         )
 
     # TeNPy bindings
@@ -169,7 +197,7 @@ def abrikosov_finite(
         B.legs[B.get_leg_index("p")] = B.get_leg("p").to_LegCharge()
 
         mask_vL = mask(B.get_leg("vL"), idx)
-        mask_vR = mask(B.get_leg("vR"), idx + 1)
+        mask_vR = mask(B.get_leg("vR"), idx + 1 if mps.finite else (idx + 1) % mps.L)
 
         # Change the occupation number leg charges to spin charges
         # --------------------------------------------------------
@@ -182,7 +210,7 @@ def abrikosov_finite(
     mps.sites = [spin_site] * mps.L
 
     mps.form = [None] * mps.L
-    mps._S = [None] * (mps.L + 1)
+    mps._S = [None] * (mps.L + 1 if mps.finite else mps.L)
 
     logger.info("Completed projection to spin-1/2 space. No conserved charges left.")
 
@@ -242,10 +270,10 @@ def abrikosov_ph(
     Returns
     -------
         The Gutzwiller projected ``mps``, if ``inplace`` is :obj:`False`.
-    
+
     Note
     ----
-        Currently, 
+        Currently,
 
         - no symmetry quantum numbers other than fermion number or parity can be handled.
         - only 'finite' and 'infinite' boundary conditions are supported.
@@ -262,22 +290,23 @@ def abrikosov_ph(
         assert isinstance(
             site, networks.FermionSite
         ), f"All sites must be fermionic, found: {site} at site {i}"
-    
+
     # TODO: support 'segment' boundary conditions
-    assert (
-        mps.bc in ["finite", "infinite"]
-    ), f"Only 'finite' and 'infinite' MPS are supported as boundary conditions, found '{mps.bc}'"
+    assert mps.bc in [
+        "finite",
+        "infinite",
+    ], f"Only 'finite' and 'infinite' MPS are supported as boundary conditions, found '{mps.bc}'"
 
     # TODO: allow for more general charge structure
     parity_pn = 0
     if mps.bc == "finite":
-        assert (
-            np.all([tensor.qtotal == 0 for tensor in mps._B])
+        assert np.all(
+            [tensor.qtotal == 0 for tensor in mps._B]
         ), "All tensors of a finite MPS must have zero total charge"
         parity_pn = mps._B[-1].get_leg("vR").charges[0] % 2
     else:
-        assert (
-            np.all([tensor.qtotal == 0 for tensor in mps._B[:-1]]) 
+        assert np.all(
+            [tensor.qtotal == 0 for tensor in mps._B[:-1]]
         ), "Except for the last, all tensors of an infinite MPS must have zero total charge"
         parity_pn = int(mps._B[-1].qtotal[0]) % 2
 
@@ -285,7 +314,7 @@ def abrikosov_ph(
         "To be able to project a MPS representing particle-hole rotated Abrikosov fermions, "
         "the total parity of the MPS must be even."
     )
-    assert (parity_pn % 2 == 0), error_msg
+    assert parity_pn % 2 == 0, error_msg
 
     if not inplace:
         mps = mps.copy()
@@ -312,7 +341,7 @@ def abrikosov_ph(
 
     # The mask for the physical leg is independent of the site
     mask_p = parity_mask(mps._B[0].get_leg("p"))
-    
+
     for idx, B in enumerate(mps._B):
         # Remove LegPipe structure
         B.legs[B.get_leg_index("p")] = B.get_leg("p").to_LegCharge()
@@ -345,13 +374,13 @@ def abrikosov_ph(
         else:  # None
             B = B.drop_charge(charge="parity_N", chinfo=chinfo_s)
 
-    if (mps.bc == 'infinite' and conserved_spin == "Sz"):
+    if mps.bc == "infinite" and conserved_spin == "Sz":
         last_tensor = mps._B[-1]
         last_tensor.qtotal = last_tensor.qtotal - mps.L
 
         last_leg = last_tensor.get_leg("vR")
         last_leg.charges += mps.L
-        
+
     mps.chinfo = chinfo_s
     mps.grouped = 1
     mps.sites = [spin_site] * mps.L

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -113,8 +113,8 @@ def abrikosov(
     q_left:
         For infinite MPS **only**, determines which fermion number/parity sector
         of the leftmost virtual leg to keep.
-        
-        Has to be a charge sector contained within :attr:`~tenpy.linalg.charges.LegCharge.charges` 
+
+        Has to be a charge sector contained within :attr:`~tenpy.linalg.charges.LegCharge.charges`
         of the leftmost virtual leg of the iMPS unit cell.
 
     Returns
@@ -151,7 +151,9 @@ def abrikosov(
     def check_charge(q: np.ndarray):
         q = q[0]
         target = mps.L // 2
-        err = f"Total charge must match number of spin sites. Got {q}, expected {target}"
+        err = (
+            f"Total charge must match number of spin sites. Got {q}, expected {target}"
+        )
         if conserved_fermion == "N":
             assert q == target, err
         else:  # parity
@@ -161,13 +163,15 @@ def abrikosov(
         check_charge(mps.get_total_charge(True))
         qtotal = None
         if q_left not in (None, 0):
-            warn(f"`q_left` must be 0 for finite MPS, got {q_left = }, setting it to 0.")
+            warn(
+                f"`q_left` must be 0 for finite MPS, got {q_left = }, setting it to 0."
+            )
         q_left = 0
     elif mps.bc == "infinite":
         check_charge(qtotal := mps.get_total_charge())
         if q_left is None:
             raise ValueError("Must specify `q_left` for infinite MPS.")
-        if q_left not in mps._B[0].get_leg("vL").charge_sectors()[:,0]:
+        if q_left not in mps._B[0].get_leg("vL").charge_sectors()[:, 0]:
             raise ValueError(
                 f"`q_left` must be a charge sector of the leftmost virtual leg, got {q_left = }, "
                 f"valid sectors are {mps._B[0].get_leg('vL').charge_sectors()}"
@@ -264,7 +268,7 @@ def abrikosov_ph(
     ----------
     mps:
         MPS representing the wave function to be projected.
-        
+
         Must be of even length and every site must be an instance
         of :class:`~tenpy.networks.site.FermionSite`.
     inplace:

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -133,44 +133,6 @@ def abrikosov(
             site, networks.FermionSite
         ), f"All sites must be fermionic, found: {site} at site {i}"
 
-    if mps.bc == "finite":
-        assert mps.get_total_charge(True)[0] == mps.L // 2
-        if q_left != 0:
-            warn(f"`q_left` must be 0 for finite MPS, ignoring {q_left = }")
-            q_left = 0
-    elif mps.bc == "infinite":
-        assert mps.get_total_charge()[0] == mps.L // 2
-    else:
-        raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
-
-    if not inplace:
-        mps = mps.copy()
-        logger.debug(f"Deep copied MPS before Gutzwiller projection.")
-
-    # normalise legs and tensor charges
-    vL_leg: npc.LegCharge = mps._B[0].get_leg("vL").copy()
-    vR_leg: npc.LegCharge = mps._B[-1].get_leg("vR").copy()
-    assert vL_leg.qconj == 1
-    assert vR_leg.qconj == -1
-    if mps.bc == "finite":
-        # want charge 0 on the left, and no tensor charges
-        assert vL_leg.ind_len == 1, "Ends of finite MPS must have chi = 1"
-        charges = vL_leg.charges.copy()
-        charges[:, 0] = 0
-        vL_leg.charges = mps.chinfo.make_valid(charges)
-        # want charge L/2 on the right
-        assert vR_leg.ind_len == 1, "Ends of finite MPS must have chi = 1"
-        charges = vR_leg.charges.copy()
-        charges[:, 0] = mps.L // 2
-        vR_leg.charges = mps.chinfo.make_valid(charges)
-    elif mps.bc == "infinite":
-        assert np.all(vL_leg.charges == vR_leg.charges), "Two ends of iMPS incompatible"
-        # want to subtract q_left from both left and right end
-        charges = vL_leg.charges.copy()
-        charges[:, 0] -= q_left
-        vL_leg.charges = vR_leg.charges = mps.chinfo.make_valid(charges)
-    mps.gauge_total_charge(vL_leg=vL_leg, vR_leg=vR_leg)
-
     conserved_fermion = mps.sites[0].conserve
     if conserved_fermion == "N":
         mask = number_mask
@@ -180,6 +142,33 @@ def abrikosov(
         raise ValueError(
             f"FermionSite must conserve either 'N' or 'parity', found {conserved_fermion!r}"
         )
+
+    def check_charge(q: np.ndarray):
+        q = q[0]
+        target = mps.L // 2
+        err = f"Total charge must match number of spin sites, {target}, got {q}"
+        if conserved_fermion == "N":
+            assert q == target, err
+        else:  # parity
+            assert q % 2 == target % 2, err + " (mod 2)"
+
+    if mps.bc == "finite":
+        check_charge(mps.get_total_charge(True))
+        qtotal = None
+        if q_left != 0:
+            warn(f"`q_left` must be 0 for finite MPS, ignoring {q_left = }")
+        q_left = 0
+    elif mps.bc == "infinite":
+        check_charge(qtotal := mps.get_total_charge())
+    else:
+        raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
+
+    if not inplace:
+        mps = mps.copy()
+        logger.debug(f"Deep copied MPS before Gutzwiller projection.")
+
+    # normalise legs and tensor charges
+    mps.gauge_total_charge(qtotal=qtotal)
 
     # TeNPy bindings
     spin_site = networks.SpinHalfSite(None)
@@ -197,8 +186,9 @@ def abrikosov(
         # Remove LegPipe structure
         B.legs[B.get_leg_index("p")] = B.get_leg("p").to_LegCharge()
 
-        mask_vL = mask(B.get_leg("vL"), idx)
-        mask_vR = mask(B.get_leg("vR"), idx + 1 if mps.finite else (idx + 1) % mps.L)
+        mask_vL = mask(B.get_leg("vL"), q_left + idx)
+        idx_next = idx + 1 if mps.finite else (idx + 1) % mps.L
+        mask_vR = mask(B.get_leg("vR"), q_left + idx_next)
 
         # Change the occupation number leg charges to spin charges
         # --------------------------------------------------------
@@ -312,11 +302,12 @@ def abrikosov_ph(
             f"FermionSite must conserve either 'N' or 'parity', found {conserved_fermion}"
         )
 
-    def check_parity(n: int):
-        assert n % 2 == 0, f"Total fermion parity of MPS must be even, got charge {n}"
+    def check_parity(q: np.ndarray):
+        q = q[0]
+        assert q % 2 == 0, f"Total fermion parity of MPS must be even, got {q}"
 
     if mps.bc == "finite":
-        check_parity(mps.get_total_charge(True)[0])
+        check_parity(mps.get_total_charge(True))
         if parity != 0:
             warn(f"Must use even parity sector in finite MPS, ignoring {parity = }")
         if offset != 0 and conserved_fermion == "N":
@@ -324,8 +315,7 @@ def abrikosov_ph(
         offset = parity = 0
         qtotal = None
     elif mps.bc == "infinite":
-        qtotal = mps.get_total_charge()
-        check_parity(qtotal[0])
+        check_parity(qtotal := mps.get_total_charge())
     else:
         # TODO: support 'segment' boundary conditions
         raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -2,7 +2,8 @@
 r"Tools for Gutzwiller projecting MPS to a smaller on-site Hilbert space."
 
 import logging
-import warnings
+from warnings import warn
+from typing import Literal
 
 import numpy as np
 
@@ -135,7 +136,7 @@ def abrikosov(
     if mps.bc == "finite":
         assert mps.get_total_charge(True)[0] == mps.L // 2
         if q_left != 0:
-            warnings.warn(f"`q_left` must be 0 for finite MPS, ignoring {q_left = }")
+            warn(f"`q_left` must be 0 for finite MPS, ignoring {q_left = }")
             q_left = 0
     elif mps.bc == "infinite":
         assert mps.get_total_charge()[0] == mps.L // 2
@@ -219,7 +220,7 @@ def abrikosov(
         mps.canonical_form(cutoff=cutoff)
         logger.info("Transformed MPS to right canonical form")
     else:
-        warnings.warn(
+        warn(
             "The MPS is not in canonical form after Gutzwiller projection.\n"
             "Consider setting 'return_canonical=True'",
         )
@@ -235,6 +236,7 @@ def abrikosov_ph(
     return_canonical: bool = True,
     cutoff: float = 1e-12,
     offset: int = 0,
+    parity: Literal[0, 1] = 0,
 ) -> None | networks.MPS:
     r"""Projection from particle-hole rotated Abrikosov fermions to a spin-1/2 Hilbert space.
 
@@ -267,15 +269,14 @@ def abrikosov_ph(
         Whether to transform the output MPS to right canonical form.
     cutoff:
         Cutoff for Schmidt values to keep in the canonical form.
+    parity:
+        For infinite MPS **only**, determines which fermion parity sector
+        of the virtual legs to keep in the projected iMPS.
     offset:
-        If the input iMPS preserves particle number, adjusts the mapping of
+        For infinite, number-preserving MPS **only**, adjusts the mapping of
         fermion number to spin on virtual legs:
+
         ``2S^z = number - offset - bond_index``
-
-        Also selects the fermion parity of virtual legs to be kept after
-        projection (also for iMPS conserving fermion parity).
-
-        Can only be specified for infinite MPS!
 
     Returns
     -------
@@ -301,16 +302,30 @@ def abrikosov_ph(
             site, networks.FermionSite
         ), f"All sites must be fermionic, found: {site} at site {i}"
 
+    conserved_fermion = mps.sites[0].conserve
+    if conserved_fermion == "N":
+        conserved_spin = "Sz"
+    elif conserved_fermion == "parity":
+        conserved_spin = None
+    else:
+        raise ValueError(
+            f"FermionSite must conserve either 'N' or 'parity', found {conserved_fermion}"
+        )
+
+    def check_parity(n: int):
+        assert n % 2 == 0, f"Total fermion parity of MPS must be even, got charge {n}"
+
     if mps.bc == "finite":
-        assert mps.get_total_charge(True)[0] % 2 == 0
-        if offset != 0:
-            warnings.warn(f"Cannot offset finite MPS, ignoring {offset = }")
+        check_parity(mps.get_total_charge(True)[0])
+        if parity != 0:
+            warn(f"Must use even parity sector in finite MPS, ignoring {parity = }")
+        if offset != 0 and conserved_fermion == "N":
+            warn(f"Cannot offset charge of finite MPS, ignoring {offset = }")
         offset = parity = 0
         qtotal = None
     elif mps.bc == "infinite":
         qtotal = mps.get_total_charge()
-        assert qtotal[0] % 2 == 0
-        parity = offset % 2
+        check_parity(qtotal[0])
     else:
         # TODO: support 'segment' boundary conditions
         raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
@@ -321,16 +336,6 @@ def abrikosov_ph(
 
     # Shift all tensor charges to the end
     mps.gauge_total_charge(qtotal=qtotal)
-
-    conserved_fermion = mps.sites[0].conserve
-    if conserved_fermion == "N":
-        conserved_spin = "Sz"
-    elif conserved_fermion == "parity":
-        conserved_spin = None
-    else:
-        raise ValueError(
-            f"FermionSite must conserve either 'N' or 'parity', found {conserved_fermion}"
-        )
 
     # TeNPy bindings
     spin_site = networks.SpinHalfSite(conserved_spin)
@@ -377,11 +382,7 @@ def abrikosov_ph(
             B = B.drop_charge(charge="parity_N", chinfo=chinfo_s)
 
     if mps.bc == "infinite" and conserved_spin == "Sz":
-        last_tensor = mps._B[-1]
-        last_tensor.qtotal = last_tensor.qtotal - mps.L
-
-        last_leg = last_tensor.get_leg("vR")
-        last_leg.charges += mps.L
+        mps._B[-1].gauge_total_charge("vR", mps._B[-1].qtotal - mps.L)
 
     mps.chinfo = chinfo_s
     mps.grouped = 1
@@ -400,7 +401,7 @@ def abrikosov_ph(
         mps.canonical_form(cutoff=cutoff)
         logger.info("Transformed MPS to right canonical form")
     else:
-        warnings.warn(
+        warn(
             "The MPS is not in canonical form after Gutzwiller projection.\n"
             "Consider setting 'return_canonical=True'",
         )

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -125,7 +125,7 @@ def abrikosov(
     ----
         Currently,
         - no symmetry quantum numbers other than fermion number or parity can be handled.
-        - only 'finite' and 'infinite' boundary conditions are supported.
+        - only ``'finite'`` and ``'infinite'`` boundary conditions are supported.
     """
 
     assert (
@@ -295,7 +295,7 @@ def abrikosov_ph(
         Currently,
 
         - no symmetry quantum numbers other than fermion number or parity can be handled.
-        - only 'finite' and 'infinite' boundary conditions are supported.
+        - only ``'finite'`` and ``'infinite'`` boundary conditions are supported.
     """
 
     assert (


### PR DESCRIPTION
In this pull request, I would like to fix the behavior of the Gutzwiller projections for Abrikosov fermions for infinite MPS.

## abrikosov

Current problems:
- For an iMPS with conserved 'N', the projection does not work. The reason for that is that we filter out particle numbers according to the current index of the tensor within the list mps._B, which only makes sense for finite MPS.
-  For an iMPS with conserved 'parity', the projection works, but one can not control which parity to keep on the incoming virtual leg on the first tensor.

Suggestion:

Split up the function into a finite and infinite version, where the infinite version takes another parameter that controls which charge block should be kept for the first virtual leg.
I have not implemented that yet because I want feedback on that idea.

## abrikosov_ph

Current problems:
- The function does not error out if the total charge of the MPS has odd parity. 
- For the iMPS case, the total charge of the last tensor is not accounted for

Suggestion:
Here, we can combine both finite and infinite cases into one function. I would currently only allow for non-trivial qtotal on the last tensor and only for the iMPS. These changes have already implemented.
