### PR TITLE
Offsets for iMPS conversion

### DIFF
--- a/src/temfpy/iMPS.py
+++ b/src/temfpy/iMPS.py
@@ -3,7 +3,7 @@ r"""Tools for converting finite to infinite MPS."""
 
 import logging
 import warnings
-from typing import NamedTuple
+from typing import NamedTuple, Literal, Iterable
 
 import numpy as np
 import tenpy.linalg.np_conserved as npc
@@ -237,6 +237,7 @@ def MPS_to_iMPS(
     cut: int,
     unitary_tol: float = _UNITARY_TOL,
     schmidt_tol: float = _SCHMIDT_TOL,
+    offset: Iterable[int | Literal["auto"]] | int | Literal["auto"] = "auto",
 ) -> tuple[nw.MPS, iMPSError]:
     """Constructs an iMPS by comparing two finite MPS.
 
@@ -271,6 +272,16 @@ def MPS_to_iMPS(
     schmidt_tol:
         Maximum mixing of unequal Schmidt values by the gauge rotation matrices
         before a warning is raised.
+    offset:
+        Charge quantum numbers to be subtracted from virtual leg charges of the
+        output iMPS.
+
+        The idea is to remove the total expected charge to the left of the iMPS
+        unit cell, so that the virtual charges of the iMPS are closer to 0.
+
+        For each conserved charge, can be either an explicit charge or ``"auto"``
+        (0 for :math:`\mathbb{Z}_N` charges, rounded weighted average for U(1) charges).
+        Default: ``"auto"`` for all charges.
 
     Returns
     -------
@@ -301,6 +312,30 @@ def MPS_to_iMPS(
 
     # Schmidt values in the short chain at the reference cut
     S0 = mps_short.get_SL(cut)
+
+    # regularise offset
+    qmod = mps_long.chinfo.mod
+    if not isinstance(offset, Iterable) or isinstance(offset, str):
+        offset = [offset] * len(qmod)
+    else:
+        assert len(offset) == len(qmod), f"Expected {len(qmod)} offsets"
+
+    def guess_offset(offset, qmod, q_flat):
+        if isinstance(offset, (int, np.integer)):
+            return offset
+        elif offset == "auto":
+            if qmod != 1:
+                return 0
+            else:
+                q_avg = (S0**2) @ q_flat
+                return round(q_avg)
+        else:
+            raise TypeError(f"Expected integer or 'auto' as offset, got {offset!r}")
+
+    vL_leg: npc.LegCharge = mps_short._B[cut].get_leg("vL").copy()
+    offset = [guess_offset(*x) for x in zip(offset, qmod, vL_leg.to_qflat().T)]
+    offset = np.asarray(offset, int)
+    vL_leg.charges = vL_leg.charges - offset  # NOT -= so we don't mess up MPS
 
     # Left gauge fixing matrix C
     bra = mps_short.extract_segment(0, cut - 1)
@@ -346,5 +381,10 @@ def MPS_to_iMPS(
     schmidt_values = [S0] + schmidt_values + [S0]
 
     iMPS = nw.MPS(sites, tensors, schmidt_values, bc="infinite", form="B")
+
+    # apply offset if nonzero
+    if not np.all(offset == 0):
+        iMPS.gauge_total_charge(vL_leg=vL_leg, vR_leg=vL_leg.conj())
+
     error = iMPSError(left_unitary, left_schmidt, right_unitary, right_schmidt)
     return iMPS, error

--- a/src/temfpy/iMPS.py
+++ b/src/temfpy/iMPS.py
@@ -96,8 +96,8 @@ def basis_rotation(
         or a right ("B", default) canonical MPS tensor.
     numerical_tol:
         Highest allowed negative value of the square of the unitary error.
-        
-        Should be more than machine precision (:math:`\sim 10^{-16}` 
+
+        Should be more than machine precision (:math:`\sim 10^{-16}`
         for ``float64``) but less than ``unitary_tol`` squared.
     unitary_tol:
         Highest allowed deviation from unitarity (weighted with Schmidt values)
@@ -145,14 +145,14 @@ def basis_rotation(
             f"the numerical tolerance {numerical_tol:.1e}."
         )
         assert_array_less(abs(unitary_error_square), numerical_tol, err_mssg)
-        logging.info(
+        logger.info(
             f"{mode.capitalize()} devitation from unitary: The square of the "
             f"unitary error {unitary_error_square:.4e} is negative, setting it to zero."
         )
         unitary_error = 0.0
     else:
         unitary_error = np.sqrt(unitary_error_square)
-        logging.info(f"{mode.capitalize()} deviation from unitary: {unitary_error:.4e}")
+        logger.info(f"{mode.capitalize()} deviation from unitary: {unitary_error:.4e}")
 
     if unitary_error > unitary_tol:
         warnings.warn(
@@ -182,7 +182,7 @@ def basis_rotation(
         Sb_C = overlap.scale_axis(Schmidt_ket, v_ket)
 
     schmidt_error = npc.norm(Sb_C - C_Sk)
-    logging.info(f"{mode.capitalize()} Schmidt value mixing:   {schmidt_error:.4e}")
+    logger.info(f"{mode.capitalize()} Schmidt value mixing:   {schmidt_error:.4e}")
     if schmidt_error > schmidt_tol:
         warnings.warn(
             f"\nMixing between unequal Schmidt value sectors on the {mode} side is\n"
@@ -197,6 +197,7 @@ class iMPSError(NamedTuple):
 
     If printed, only non-zero approximation errors are displayed.
     """
+
     left_unitary: float
     """Deviation of left environment from unitarity."""
     left_schmidt: float

--- a/src/temfpy/iMPS.py
+++ b/src/temfpy/iMPS.py
@@ -298,7 +298,8 @@ def MPS_to_iMPS(
             "The given two MPS must differ by one unit cell, got "
             f"{L_long} - {L_short} != {sites_per_cell}"
         )
-    if mps_short.chinfo != mps_long.chinfo:
+    chinfo: npc.ChargeInfo = mps_short.chinfo
+    if chinfo != mps_long.chinfo:
         raise ValueError("Incompatible ChargeInfo in the two MPS")
     assert all(x is not None for x in mps_short.form), "mps_short is not canonical"
     assert all(x is not None for x in mps_long.form), "mps_long is not canonical"
@@ -314,7 +315,7 @@ def MPS_to_iMPS(
     S0 = mps_short.get_SL(cut)
 
     # regularise offset
-    qmod = mps_long.chinfo.mod
+    qmod = chinfo.mod
     if not isinstance(offset, Iterable) or isinstance(offset, str):
         offset = [offset] * len(qmod)
     else:
@@ -335,7 +336,7 @@ def MPS_to_iMPS(
     vL_leg: npc.LegCharge = mps_short._B[cut].get_leg("vL").copy()
     offset = [guess_offset(*x) for x in zip(offset, qmod, vL_leg.to_qflat().T)]
     offset = np.asarray(offset, int)
-    vL_leg.charges = vL_leg.charges - offset  # NOT -= so we don't mess up MPS
+    vL_leg.charges = chinfo.make_valid(vL_leg.charges - offset)
 
     # Left gauge fixing matrix C
     bra = mps_short.extract_segment(0, cut - 1)

--- a/src/temfpy/iMPS.py
+++ b/src/temfpy/iMPS.py
@@ -318,6 +318,7 @@ def MPS_to_iMPS(
     qmod = chinfo.mod
     if not isinstance(offset, Iterable) or isinstance(offset, str):
         offset = [offset] * len(qmod)
+        logger.info(f"Using {offset = !r} for all conserved charges")
     else:
         assert len(offset) == len(qmod), f"Expected {len(qmod)} offsets"
 
@@ -336,6 +337,7 @@ def MPS_to_iMPS(
     vL_leg: npc.LegCharge = mps_short._B[cut].get_leg("vL").copy()
     offset = [guess_offset(*x) for x in zip(offset, qmod, vL_leg.to_qflat().T)]
     offset = np.asarray(offset, int)
+    logger.info("Using charge offsets {offset}")
     vL_leg.charges = chinfo.make_valid(vL_leg.charges - offset)
 
     # Left gauge fixing matrix C

--- a/src/temfpy/slater.py
+++ b/src/temfpy/slater.py
@@ -1350,6 +1350,7 @@ def C_to_iMPS(
     unitary_tol: float = iMPS._UNITARY_TOL,
     schmidt_tol: float = iMPS._SCHMIDT_TOL,
     spinful: Literal["simple", "PH", None] = None,
+    offset: int | Literal["auto"] = "auto",
 ) -> tuple[networks.MPS, iMPS.iMPSError]:
     r"""iMPS representation of a Slater determinant from correlation matrices.
 
@@ -1399,6 +1400,12 @@ def C_to_iMPS(
         spin-rotation symmetric state of spinful fermions or not (``None``),
         either with (``"PH"``) or without (``"simple"``) particle-hole
         rotation in the down-spin sector.
+    offset:
+        Charge quantum number to be subtracted from virtual leg charges of the
+        output iMPS.
+
+        Defaults to expected particle number left of ``cut`` in the shorter chain,
+        rounded to the nearest integer (``"auto"``).
 
     Returns
     -------
@@ -1447,6 +1454,9 @@ def C_to_iMPS(
         f"{L_long} - {L_short} != {sites_per_cell}"
     )
 
+    if offset == "auto":
+        offset = round(np.trace(C_short[:cut, :cut]))
+
     # lists for accumulating the tensors and singular values
     tensors = []
     λs = []
@@ -1476,6 +1486,10 @@ def C_to_iMPS(
         # compute the tensor
         B = MPSTensorData.from_schmidt_vectors(Schmidt_new, Schmidt, "right")
         B = B.to_npc_array()
+        # subtract offset != 0 from virtual legs
+        if offset != 0:
+            B.get_leg("vL").charges -= offset
+            B.get_leg("vR").charges -= offset
         tensors.append(B)
 
         logger.info(f"Tensor norm on site {i}: {npc.norm(B) / len(λs[i]) ** 0.5}")
@@ -1554,9 +1568,11 @@ def H_to_MPS(
     """
 
     C, _ = correlation_matrix(H)
-    return C_to_MPS(C, trunc_par, diag_tol=diag_tol, ortho_center=ortho_center, spinful=spinful)
+    return C_to_MPS(
+        C, trunc_par, diag_tol=diag_tol, ortho_center=ortho_center, spinful=spinful
+    )
 
-    
+
 def H_to_iMPS(
     H_short: np.ndarray,
     H_long: np.ndarray,
@@ -1568,10 +1584,11 @@ def H_to_iMPS(
     unitary_tol: float = iMPS._UNITARY_TOL,
     schmidt_tol: float = iMPS._SCHMIDT_TOL,
     spinful: Literal["simple", "PH", None] = None,
+    offset: int | Literal["auto"] = "auto",
 ) -> tuple[networks.MPS, iMPS.iMPSError]:
     r"""iMPS representation of a Slater determinant from single particle Hamiltonians.
 
-    It is expected that the two single-particle Hamiltonians describe two 
+    It is expected that the two single-particle Hamiltonians describe two
     translation-invariant systems that differ by one repeating unit cell.
 
     The method is analogous to :func:`.iMPS.MPS_to_iMPS`, with two differences:
@@ -1615,6 +1632,12 @@ def H_to_iMPS(
         spin-rotation symmetric state of spinful fermions or not (``None``),
         either with (``"PH"``) or without (``"simple"``) particle-hole
         rotation in the down-spin sector.
+    offset:
+        Charge quantum number to be subtracted from virtual leg charges of the
+        output iMPS.
+
+        Defaults to expected particle number left of ``cut`` in the shorter chain,
+        rounded to the nearest integer (``"auto"``).
 
     Returns
     -------
@@ -1645,4 +1668,5 @@ def H_to_iMPS(
         unitary_tol=unitary_tol,
         schmidt_tol=schmidt_tol,
         spinful=spinful,
+        offset=offset,
     )

--- a/src/temfpy/slater.py
+++ b/src/temfpy/slater.py
@@ -1407,6 +1407,10 @@ def C_to_iMPS(
         Defaults to expected particle number left of ``cut`` in the shorter chain,
         rounded to the nearest integer (``"auto"``).
 
+        If ``spinful == "simple"``, it is interpreted *per spin species*, i.e.,
+        the actual offset in particle number is ``2 * offset``. As such, the
+        automatic offset is guaranteed to be even.
+
     Returns
     -------
     iMPS: :class:`~tenpy.networks.mps.MPS`
@@ -1427,6 +1431,12 @@ def C_to_iMPS(
     trunc_par = to_stopping_condition(trunc_par)
 
     if spinful == "simple":
+        if offset == "auto":  # NB C_short and cut not yet doubled
+            offset = 2 * round(np.trace(C_short[:cut, :cut]))
+            logger.info(f"Using total offset {offset} for conserved fermion number")
+        else:
+            offset *= 2
+            logger.debug(f"Offset doubled to {offset} for spinful fermions")
         C_short = spinful_correlation_matrix(C_short, False)
         C_long = spinful_correlation_matrix(C_long, False)
         sites_per_cell *= 2
@@ -1454,7 +1464,7 @@ def C_to_iMPS(
         f"{L_long} - {L_short} != {sites_per_cell}"
     )
 
-    if offset == "auto":
+    if offset == "auto":  # NB took care of spinful="simple" already
         offset = round(np.trace(C_short[:cut, :cut]))
         logger.info(f"Using offset {offset} for conserved fermion number")
 
@@ -1639,6 +1649,10 @@ def H_to_iMPS(
 
         Defaults to expected particle number left of ``cut`` in the shorter chain,
         rounded to the nearest integer (``"auto"``).
+
+        If ``spinful == "simple"``, it is interpreted *per spin species*, i.e.,
+        the actual offset in particle number is ``2 * offset``. As such, the
+        automatic offset is guaranteed to be even.
 
     Returns
     -------

--- a/src/temfpy/slater.py
+++ b/src/temfpy/slater.py
@@ -1456,6 +1456,7 @@ def C_to_iMPS(
 
     if offset == "auto":
         offset = round(np.trace(C_short[:cut, :cut]))
+        logger.info(f"Using offset {offset} for conserved fermion number")
 
     # lists for accumulating the tensors and singular values
     tensors = []


### PR DESCRIPTION
By default, iMPS constructed from finite MPS with our method inherits the virtual leg charges of the shorter MPS it is constructed out of. This might be inconvenient especially for U(1) charges (e.g. particle number), which would grow quite far from zero for a long chain.

This PR introduces an `offset` parameter to such conversion functions to allow removing these offsets. We also provide a default `"auto"` option that guesses the correct amount of offset, by the following logic:
- For non-U(1) charges, no offset (it's difficult to really decide what the correct "average value" is for a cyclic charge)
- For U(1) charges in a generic MPS conversion, offset by the average (weighted by Schmidt values) charge of the cut virtual leg of the shorter chain, rounded to the nearest integer
- For U(1) fermion number in Slater determinants, offset by the expected fermion number (aka trace of the correlation matrix) of the left subsystem of the shorter chain, rounded to the nearest integer
 
 @simonhille, happy with the heuristics?

Also fixes #19