### PR TITLE
Fix real eigenvector search in `pfaffian`, stricter tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 ### API breaking changes
 
+* By default, the iMPS creation routines {func}`temfpy.slater.C_to_iMPS`, {func}`temfpy.slater.H_to_iMPS`, and {func}`temfpy.iMPS.MPS_to_iMPS` now subtract an estimate of the total U(1) charge to the left of the extracted unit cell from the quantum numbers on the virtual legs of the iMPS. The amount of this offset can be controlled with the new `offset` parameter; the old behaviour can be restored using `offset=0`. [#20](https://github.com/temfpy/temfpy/pull/20)
+
 ### New features
 
 * Gutzwiller projections {func}`temfpy.gutzwiller.abrikosov` and {func}`temfpy.gutzwiller.abrikosov_ph` allow targeting different virtual charge/parity sectors, which may give access to different topological sectors. [#18](https://github.com/temfpy/temfpy/pull/18)
+* All functions that create an {class}`~tenpy.networks.mps.MPS` support an optional `unit_cell_width` argument for specifying the physical length of the system being simulated. Sensible defaults are also provided. [#21](https://github.com/temfpy/temfpy/pull/21)
 
 ### Bug fixes
 
@@ -16,7 +19,7 @@
 
 ### Bug fixes
 
-* Fix ill-defined unitary errors during iMPS conversion. [#14](https://github.com/temfpy/temfpy/pull/14)
+* Fixed ill-defined unitary errors during iMPS conversion. [#14](https://github.com/temfpy/temfpy/pull/14)
 * Improved the documentation and fixed typos. [#13](https://github.com/temfpy/temfpy/pull/13)
 
 ## TeMFpy 0.2 (23 January 2026)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,15 +3,16 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import os
+import temfpy
 
 # -- Project information -- #
 # ------------------------- #
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "TeMFpy"
-copyright = "2025, Simon Hans Hille, Attila Szabó"
+copyright = "2025-%Y, Simon Hans Hille, Attila Szabó"
 author = "Simon Hans Hille, Attila Szabó"
-release = "2025"
+version = release = temfpy.__version__
 
 # -- General configuration -- #
 # --------------------------- #

--- a/src/temfpy/__init__.py
+++ b/src/temfpy/__init__.py
@@ -43,6 +43,7 @@ def __getattr__(name):
     """Lazy load modules on first access."""
     if name in _lazy_modules:
         import importlib
+
         module = importlib.import_module(_lazy_modules[name])
         globals()[name] = module
         return module

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -40,7 +40,7 @@ def parity_mask(leg: npc.charges.LegCharge, parity: int = 0) -> np.ndarray:
     Returns
     -------
         A boolean mask selecting the physical charge blocks
-        that can be used by :class:`~tenpy.networks.Array.iproject`.
+        that can be used by :func:`~tenpy.linalg.np_conserved.Array.iproject`.
 
     """
     mask = (leg.to_qflat() % 2 == parity % 2).ravel()
@@ -63,7 +63,7 @@ def number_mask(leg: npc.charges.LegCharge, n: int) -> np.ndarray:
     Returns
     -------
         A boolean mask selecting the physical charge block
-        that can be used by :class:`~tenpy.networks.Array.iproject`.
+        that can be used by :func:`~tenpy.linalg.np_conserved.Array.iproject`.
     """
     mask = (leg.to_qflat() == n).ravel()
 
@@ -132,6 +132,7 @@ def abrikosov(
     Note
     ----
         Currently,
+
         - no symmetry quantum numbers other than fermion number or parity can be handled.
         - only ``'finite'`` and ``'infinite'`` boundary conditions are supported.
     """

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -81,6 +81,7 @@ def abrikosov(
     return_canonical: bool = True,
     cutoff: float = 1e-12,
     q_left: None | int = None,
+    unit_cell_width: int | None = None,
 ) -> None | networks.MPS:
     r"""Projection from Abrikosov fermions to a spin-1/2 Hilbert space.
 
@@ -116,6 +117,13 @@ def abrikosov(
 
         Has to be a charge sector contained within :attr:`~tenpy.linalg.charges.LegCharge.charges`
         of the leftmost virtual leg of the iMPS unit cell.
+    unit_cell_width:
+        Physical length of the system represented by the MPS.
+
+        If ``None`` (default), keep the existing
+        :attr:`~tenpy.networks.mps.MPSGeometry.unit_cell_width` if it divides
+        the new, halved, system size. Otherwise, replace with the new MPS length
+        (i.e., treat it as a chain).
 
     Returns
     -------
@@ -184,6 +192,20 @@ def abrikosov(
         mps = mps.copy()
         logger.debug(f"Deep copied MPS before Gutzwiller projection.")
 
+    # normalise unit_cell_width
+    if unit_cell_width is None:
+        unit_cell_width = mps.unit_cell_width
+        if (mps.L // 2) % unit_cell_width != 0:
+            warn(
+                f"Input MPS {unit_cell_width = } does not divide new MPS size {mps.L//2}, discard"
+            )
+            unit_cell_width = mps.L // 2
+    elif (mps.L // 2) % unit_cell_width != 0:
+        raise ValueError(
+            f"{unit_cell_width = } does not divide new MPS size {mps.L//2}"
+        )
+    mps.unit_cell_width = unit_cell_width
+
     # normalise legs and tensor charges
     mps.gauge_total_charge(qtotal=qtotal)
 
@@ -244,6 +266,7 @@ def abrikosov_ph(
     cutoff: float = 1e-12,
     offset: int = 0,
     parity: Literal[0, 1] = 0,
+    unit_cell_width: int | None = None,
 ) -> None | networks.MPS:
     r"""Projection from particle-hole rotated Abrikosov fermions to a spin-1/2 Hilbert space.
 
@@ -285,6 +308,13 @@ def abrikosov_ph(
         fermion number to spin on virtual legs:
 
         ``2S^z = number - offset - bond_index``
+    unit_cell_width:
+        Physical length of the system represented by the MPS.
+
+        If ``None`` (default), keep the existing
+        :attr:`~tenpy.networks.mps.MPSGeometry.unit_cell_width` if it divides
+        the new, halved, system size. Otherwise, replace with the new MPS length
+        (i.e., treat it as a chain).
 
     Returns
     -------
@@ -339,6 +369,20 @@ def abrikosov_ph(
     if not inplace:
         mps = mps.copy()
         logger.debug(f"Deep copied MPS before Gutzwiller projection.")
+
+    # normalise unit_cell_width
+    if unit_cell_width is None:
+        unit_cell_width = mps.unit_cell_width
+        if (mps.L // 2) % unit_cell_width != 0:
+            warn(
+                f"Input MPS {unit_cell_width = } does not divide new MPS size {mps.L//2}, discard"
+            )
+            unit_cell_width = mps.L // 2
+    elif (mps.L // 2) % unit_cell_width != 0:
+        raise ValueError(
+            f"{unit_cell_width = } does not divide new MPS size {mps.L//2}"
+        )
+    mps.unit_cell_width = unit_cell_width
 
     # Shift all tensor charges to the end
     mps.gauge_total_charge(qtotal=qtotal)

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -70,6 +70,24 @@ def number_mask(leg: npc.charges.LegCharge, n: int) -> np.ndarray:
     return mask
 
 
+def _check_unit_cell_width(
+    mps: networks.MPS, unit_cell_width: int | None, group: int = 2
+):
+    if unit_cell_width is None:
+        unit_cell_width = mps.unit_cell_width
+        if (mps.L // group) % unit_cell_width != 0:
+            warn(
+                f"Input MPS {unit_cell_width = } does not divide new MPS size "
+                f"{mps.L // group}\nDefault to chain geometry"
+            )
+            unit_cell_width = mps.L // group
+    elif (mps.L // group) % unit_cell_width != 0:
+        raise ValueError(
+            f"{unit_cell_width = } does not divide new MPS size {mps.L // group}"
+        )
+    mps.unit_cell_width = unit_cell_width
+
+
 # Gutzwiller projections
 # ----------------------
 
@@ -194,18 +212,7 @@ def abrikosov(
         logger.debug(f"Deep copied MPS before Gutzwiller projection.")
 
     # normalise unit_cell_width
-    if unit_cell_width is None:
-        unit_cell_width = mps.unit_cell_width
-        if (mps.L // 2) % unit_cell_width != 0:
-            warn(
-                f"Input MPS {unit_cell_width = } does not divide new MPS size {mps.L//2}, discard"
-            )
-            unit_cell_width = mps.L // 2
-    elif (mps.L // 2) % unit_cell_width != 0:
-        raise ValueError(
-            f"{unit_cell_width = } does not divide new MPS size {mps.L//2}"
-        )
-    mps.unit_cell_width = unit_cell_width
+    _check_unit_cell_width(mps, unit_cell_width)
 
     # normalise legs and tensor charges
     mps.gauge_total_charge(qtotal=qtotal)
@@ -372,18 +379,7 @@ def abrikosov_ph(
         logger.debug(f"Deep copied MPS before Gutzwiller projection.")
 
     # normalise unit_cell_width
-    if unit_cell_width is None:
-        unit_cell_width = mps.unit_cell_width
-        if (mps.L // 2) % unit_cell_width != 0:
-            warn(
-                f"Input MPS {unit_cell_width = } does not divide new MPS size {mps.L//2}, discard"
-            )
-            unit_cell_width = mps.L // 2
-    elif (mps.L // 2) % unit_cell_width != 0:
-        raise ValueError(
-            f"{unit_cell_width = } does not divide new MPS size {mps.L//2}"
-        )
-    mps.unit_cell_width = unit_cell_width
+    _check_unit_cell_width(mps, unit_cell_width)
 
     # Shift all tensor charges to the end
     mps.gauge_total_charge(qtotal=qtotal)

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -40,7 +40,7 @@ def parity_mask(leg: npc.charges.LegCharge, parity: int = 0) -> np.ndarray:
     Returns
     -------
         A boolean mask selecting the physical charge blocks
-        that can be used by :func:`~tenpy.linalg.np_conserved.Array.iproject`.
+        that can be used by :meth:`~tenpy.linalg.np_conserved.Array.iproject`.
 
     """
     mask = (leg.to_qflat() % 2 == parity % 2).ravel()
@@ -63,7 +63,7 @@ def number_mask(leg: npc.charges.LegCharge, n: int) -> np.ndarray:
     Returns
     -------
         A boolean mask selecting the physical charge block
-        that can be used by :func:`~tenpy.linalg.np_conserved.Array.iproject`.
+        that can be used by :meth:`~tenpy.linalg.np_conserved.Array.iproject`.
     """
     mask = (leg.to_qflat() == n).ravel()
 

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -120,7 +120,7 @@ def abrikosov(
     unit_cell_width:
         Physical length of the system represented by the MPS.
 
-        If ``None`` (default), keep the existing
+        If :obj:`None` (default), keep the existing
         :attr:`~tenpy.networks.mps.MPSGeometry.unit_cell_width` if it divides
         the new, halved, system size. Otherwise, replace with the new MPS length
         (i.e., treat it as a chain).
@@ -312,7 +312,7 @@ def abrikosov_ph(
     unit_cell_width:
         Physical length of the system represented by the MPS.
 
-        If ``None`` (default), keep the existing
+        If :obj:`None` (default), keep the existing
         :attr:`~tenpy.networks.mps.MPSGeometry.unit_cell_width` if it divides
         the new, halved, system size. Otherwise, replace with the new MPS length
         (i.e., treat it as a chain).

--- a/src/temfpy/iMPS.py
+++ b/src/temfpy/iMPS.py
@@ -240,7 +240,7 @@ def MPS_to_iMPS(
     offset: Iterable[int | Literal["auto"]] | int | Literal["auto"] = "auto",
     unit_cell_width: int | None = None,
 ) -> tuple[nw.MPS, iMPSError]:
-    """Constructs an iMPS by comparing two finite MPS.
+    r"""Constructs an iMPS by comparing two finite MPS.
 
     The two MPS are expected to represent the ground states of a gapped,
     translation invariant Hamiltonian on two system sizes that differ by

--- a/src/temfpy/iMPS.py
+++ b/src/temfpy/iMPS.py
@@ -286,7 +286,7 @@ def MPS_to_iMPS(
     unit_cell_width:
         Physical length of the iMPS unit cell.
 
-        If ``None`` (default), try to infer from
+        If :obj:`None` (default), try to infer from
         :attr:`~tenpy.networks.mps.MPSGeometry.N_sites_per_hor_spacing`
         (aka cylinder width) of the two input MPS:
 
@@ -342,7 +342,7 @@ def MPS_to_iMPS(
         cylinder1 = sites_per_cell // unit_cell_width
         assert (
             cut % cylinder1 == 0
-        ), f"{cut = } does not divide requested cylinder circumference {cylinder1}"
+        ), f"{cut = } not divisible into requested cylinder circumferences of {cylinder1}"
 
     # set unit_cell_width of input MPS to match the new cylinder width
     # so `MPS.extract_segment` doesn't complain

--- a/src/temfpy/iMPS.py
+++ b/src/temfpy/iMPS.py
@@ -238,6 +238,7 @@ def MPS_to_iMPS(
     unitary_tol: float = _UNITARY_TOL,
     schmidt_tol: float = _SCHMIDT_TOL,
     offset: Iterable[int | Literal["auto"]] | int | Literal["auto"] = "auto",
+    unit_cell_width: int | None = None,
 ) -> tuple[nw.MPS, iMPSError]:
     """Constructs an iMPS by comparing two finite MPS.
 
@@ -282,6 +283,20 @@ def MPS_to_iMPS(
         For each conserved charge, can be either an explicit charge or ``"auto"``
         (0 for :math:`\mathbb{Z}_N` charges, rounded weighted average for U(1) charges).
         Default: ``"auto"`` for all charges.
+    unit_cell_width:
+        Physical length of the iMPS unit cell.
+
+        If ``None`` (default), try to infer from
+        :attr:`~tenpy.networks.mps.MPSGeometry.N_sites_per_hor_spacing`
+        (aka cylinder width) of the two input MPS:
+
+        - If they're the same and ``cut`` is also a multiple (i.e., it corresponds
+          to whole cylinder rungs), keep the same cylinder width for the iMPS.
+        - Otherwise, discard both and default to ``sites_per_cell`` (i.e., a chain).
+
+        If specified, it must divide ``sites_per_cell`` and the quotient
+        (i.e., the cylinder width) must divide ``cut`` (i.e., the iMPS unit cell
+        must correspond to whole rungs of the cylinder).
 
     Returns
     -------
@@ -304,12 +319,37 @@ def MPS_to_iMPS(
     assert all(x is not None for x in mps_short.form), "mps_short is not canonical"
     assert all(x is not None for x in mps_long.form), "mps_long is not canonical"
 
-    # TODO: In TenPy unit_cell_width for a segment is
-    # TODO: not set correctly. If this is fixed by TenPy, remove workaround
-    # ------------------------
-    mps_short.unit_cell_width = mps_short.L
-    mps_long.unit_cell_width = mps_long.L
-    # ------------------------
+    if unit_cell_width is None:
+        cylinder1 = mps_short.N_sites_per_hor_spacing
+        cylinder2 = mps_long.N_sites_per_hor_spacing
+        if cylinder1 != cylinder2:
+            warnings.warn(
+                f"Unequal cylinder circumferences {cylinder1}, {cylinder2},\n"
+                "discard `unit_cell_width` of input MPS"
+            )
+            cylinder1 = cylinder2 = 1
+        if cut % cylinder1 != 0:
+            warnings.warn(
+                f"{cut = } not divisible into cylinder circumferences of {cylinder1},\n"
+                "discard `unit_cell_width` of input MPS"
+            )
+            cylinder1 = cylinder2 = 1
+        unit_cell_width = sites_per_cell // cylinder1
+    else:
+        assert (
+            sites_per_cell % unit_cell_width == 0
+        ), f"{unit_cell_width = } does not divide {sites_per_cell = }"
+        cylinder1 = sites_per_cell // unit_cell_width
+        assert (
+            cut % cylinder1 == 0
+        ), f"{cut = } does not divide requested cylinder circumference {cylinder1}"
+
+    # set unit_cell_width of input MPS to match the new cylinder width
+    # so `MPS.extract_segment` doesn't complain
+    # save the existing values to restore them at the end
+    ucw_old = mps_short.unit_cell_width, mps_long.unit_cell_width
+    mps_short.unit_cell_width = mps_short.L // cylinder1
+    mps_long.unit_cell_width = mps_long.L // cylinder1
 
     # Schmidt values in the short chain at the reference cut
     S0 = mps_short.get_SL(cut)
@@ -383,7 +423,15 @@ def MPS_to_iMPS(
     # Set Schmidt values on both ends to that of the reference MPS
     schmidt_values = [S0] + schmidt_values + [S0]
 
-    iMPS = nw.MPS(sites, tensors, schmidt_values, bc="infinite", form="B")
+    iMPS = nw.MPS(
+        sites,
+        tensors,
+        schmidt_values,
+        bc="infinite",
+        form="B",
+        unit_cell_width=unit_cell_width,
+    )
+    mps_short.unit_cell_width, mps_long.unit_cell_width = ucw_old
 
     # apply offset if nonzero
     if not np.all(offset == 0):

--- a/src/temfpy/pfaffian.py
+++ b/src/temfpy/pfaffian.py
@@ -808,7 +808,7 @@ class SchmidtModes:
                 w = np.column_stack((v[:, x0:x1].real, v[:, x0:x1].imag))
                 w, s, _ = svd(w)
 
-                s_exp = [1] * (2 * kh) + [0] * (2 * kh)
+                s_exp = [1] * (2 * kh) + [0] * (s.size - 2 * kh)
                 err = "1/2 eigenvectors cannot be made real"
                 assert_allclose(s, s_exp, rtol=0, atol=diag_tol, err_msg=err)
 

--- a/src/temfpy/pfaffian.py
+++ b/src/temfpy/pfaffian.py
@@ -1769,6 +1769,7 @@ class MPSTensorData:
 #### High-level functions ####
 #### -------------------- ####
 
+
 def C_to_MPS(
     C: np.ndarray,
     trunc_par: dict | StoppingCondition,
@@ -1776,6 +1777,7 @@ def C_to_MPS(
     basis: str,
     diag_tol: float = _DIAG_TOL,
     ortho_center: int = None,
+    unit_cell_width: int | None = None,
 ) -> networks.MPS:
     r"""
     MPS representation of a Nambu mean-field ground state from its correlation matrix.
@@ -1800,6 +1802,9 @@ def C_to_MPS(
     diag_tol:
         Largest allowed offdiagonal matrix element in diagonalised / SVD
         correlation submatrices before an error is raised.
+    unit_cell_width:
+        Physical length of the chain or cylinder being simulated.
+        Defaults to the number of sites.
 
     Returns
     -------
@@ -1815,6 +1820,11 @@ def C_to_MPS(
     trunc_par = to_stopping_condition(trunc_par)
 
     L = len(C) // 2
+
+    if unit_cell_width is None:
+        unit_cell_width = L
+    elif L % unit_cell_width != 0:
+        raise ValueError(f"{unit_cell_width = } does not divide system size {L}")
 
     # lists for accumulating the tensors and singular values
     tensors = [None] * L
@@ -1892,7 +1902,9 @@ def C_to_MPS(
         Schmidt = Schmidt_new
 
     form = ["A"] * ortho_center + ["B"] * (L - ortho_center)
-    mps = networks.mps.MPS([fermion_site] * L, tensors, λs, form=form)
+    mps = networks.mps.MPS(
+        [fermion_site] * L, tensors, λs, form=form, unit_cell_width=unit_cell_width
+    )
 
     return mps
 
@@ -1908,6 +1920,7 @@ def C_to_iMPS(
     diag_tol: float = _DIAG_TOL,
     unitary_tol: float = iMPS._UNITARY_TOL,
     schmidt_tol: float = iMPS._SCHMIDT_TOL,
+    unit_cell_width: int | None = None,
 ) -> tuple[networks.MPS, iMPS.iMPSError]:
     r"""iMPS representation of a Nambu mean-field state from correlation matrices.
 
@@ -1956,6 +1969,9 @@ def C_to_iMPS(
     schmidt_tol:
         Maximum mixing of unequal Schmidt values by the gauge rotation matrices
         before a warning is raised.
+    unit_cell_width:
+        Physical length of the chain or cylinder being simulated.
+        Defaults to ``sites_per_cell``.
 
     Returns
     -------
@@ -1986,6 +2002,11 @@ def C_to_iMPS(
         "The given two MPS must differ by one unit cell, got "
         f"{L_long} - {L_short} != {sites_per_cell}"
     )
+
+    if unit_cell_width is None:
+        unit_cell_width = sites_per_cell
+    elif sites_per_cell % unit_cell_width != 0:
+        raise ValueError(f"{unit_cell_width = } does not divide {sites_per_cell = }")
 
     # lists for accumulating the tensors and singular values
     tensors = []
@@ -2048,7 +2069,12 @@ def C_to_iMPS(
     tensors[0] = npc.tensordot(C, tensors[0], axes=["vR", "vL"])
 
     iMPS_ = networks.MPS(
-        [fermion_site] * sites_per_cell, tensors, λs, bc="infinite", form="B"
+        [fermion_site] * sites_per_cell,
+        tensors,
+        λs,
+        bc="infinite",
+        form="B",
+        unit_cell_width=unit_cell_width,
     )
     error = iMPS.iMPSError(left_unitary, left_schmidt, 0.0, 0.0)
     return iMPS_, error
@@ -2061,6 +2087,7 @@ def H_to_MPS(
     basis: str,
     diag_tol: float = _DIAG_TOL,
     ortho_center: int = None,
+    unit_cell_width: int | None = None,
 ) -> networks.MPS:
     r"""MPS representation of a Nambu mean-field ground state from its single particle Hamiltonian.
 
@@ -2084,6 +2111,9 @@ def H_to_MPS(
     diag_tol:
         Largest allowed offdiagonal matrix element in diagonalised / SVD
         correlation submatrices before an error is raised.
+    unit_cell_width:
+        Physical length of the chain or cylinder being simulated.
+        Defaults to the number of sites.
 
     Returns
     -------
@@ -2103,6 +2133,7 @@ def H_to_MPS(
         basis=basis,
         diag_tol=diag_tol,
         ortho_center=ortho_center,
+        unit_cell_width=unit_cell_width,
     )
 
 
@@ -2117,10 +2148,11 @@ def H_to_iMPS(
     diag_tol: float = _DIAG_TOL,
     unitary_tol: float = iMPS._UNITARY_TOL,
     schmidt_tol: float = iMPS._SCHMIDT_TOL,
+    unit_cell_width: int | None = None,
 ) -> tuple[networks.MPS, iMPS.iMPSError]:
     r"""iMPS representation of a Nambu mean-field state from single particle hamiltonians.
 
-    It is expected that the two single-particle Hamiltonians describe two 
+    It is expected that the two single-particle Hamiltonians describe two
     translation-invariant systems that differ by one repeating unit cell.
 
     The method is analogous to :func:`.iMPS.MPS_to_iMPS`, with two differences:
@@ -2164,6 +2196,9 @@ def H_to_iMPS(
     schmidt_tol:
         Maximum mixing of unequal Schmidt values by the gauge rotation matrices
         before a warning is raised.
+    unit_cell_width:
+        Physical length of the chain or cylinder being simulated.
+        Defaults to ``sites_per_cell``.
 
     Returns
     -------
@@ -2180,7 +2215,7 @@ def H_to_iMPS(
     - If :attr:`trunc_par.degeneracy_tol` is not provided, the degeneracy tolerance
       defaults to 1e-12.
     """
-        
+
     C_short = correlation_matrix(H_short, basis=f"{basis}->{basis}")
     C_long = correlation_matrix(H_long, basis=f"{basis}->{basis}")
     return C_to_iMPS(
@@ -2193,5 +2228,5 @@ def H_to_iMPS(
         diag_tol=diag_tol,
         unitary_tol=unitary_tol,
         schmidt_tol=schmidt_tol,
+        unit_cell_width=unit_cell_width,
     )
-

--- a/src/temfpy/pfaffian.py
+++ b/src/temfpy/pfaffian.py
@@ -1026,7 +1026,7 @@ class SchmidtVectors:
     r"""Dictionary mapping the number of :math:`\gamma^\dagger` excitations
     to slice of sets/singular values corresponding to that excitation number.
 
-    That is, each row in ``left_sets[idx_n[n]]`` contains n ``True`` entries.
+    That is, each row in ``left_sets[idx_n[n]]`` contains n :obj:`True` entries.
 
     Slices follow each other in the order 0, 2,..., 1, 3,...
     """
@@ -1035,7 +1035,7 @@ class SchmidtVectors:
     to slice of sets/singular values corresponding to that excitation number.
 
     That is, each row in ``left_sets[idx_parity[n]]`` contains an even (odd)
-    number of ``True`` entries if n=0 (1).
+    number of :obj:`True` entries if n=0 (1).
     """
 
     @property
@@ -1532,7 +1532,7 @@ class MPSTensorData:
     """Bra Schmidt vectors in terms of the excitations in :attr:`pfaffian_matrix`.
     
     Given the block structure of :attr:`pfaffian_matrix`, each row starts with
-    a number of ``False`` entries corresponding to the ket excitations.
+    a number of :obj:`False` entries corresponding to the ket excitations.
     
     If the tensor contains a physical leg, it is double the length of
     :attr:`~SchmidtVectors.sets` and contains all Schmidt vectors with the on-site
@@ -1558,7 +1558,7 @@ class MPSTensorData:
     """Ket Schmidt vectors in terms of the excitations in :attr:`pfaffian_matrix`.
     
     Given the block structure of :attr:`pfaffian_matrix`, each row ends with
-    a number of ``False`` entries corresponding to the bra excitations.
+    a number of :obj:`False` entries corresponding to the bra excitations.
     """
     idx_n_ket: np.ndarray
     """:attr:`~SchmidtVectors.idx_n` of the ket Schmidt vector."""

--- a/src/temfpy/pfaffian.py
+++ b/src/temfpy/pfaffian.py
@@ -1970,8 +1970,7 @@ def C_to_iMPS(
         Maximum mixing of unequal Schmidt values by the gauge rotation matrices
         before a warning is raised.
     unit_cell_width:
-        Physical length of the chain or cylinder being simulated.
-        Defaults to ``sites_per_cell``.
+        Physical length of the iMPS unit cell. Defaults to ``sites_per_cell``.
 
     Returns
     -------
@@ -2197,8 +2196,7 @@ def H_to_iMPS(
         Maximum mixing of unequal Schmidt values by the gauge rotation matrices
         before a warning is raised.
     unit_cell_width:
-        Physical length of the chain or cylinder being simulated.
-        Defaults to ``sites_per_cell``.
+        Physical length of the iMPS unit cell. Defaults to ``sites_per_cell``.
 
     Returns
     -------

--- a/src/temfpy/slater.py
+++ b/src/temfpy/slater.py
@@ -1426,8 +1426,7 @@ def C_to_iMPS(
         the actual offset in particle number is ``2 * offset``. As such, the
         automatic offset is guaranteed to be even.
     unit_cell_width:
-        Physical length of the chain or cylinder being simulated.
-        Defaults to ``sites_per_cell``.
+        Physical length of the iMPS unit cell. Defaults to ``sites_per_cell``.
 
     Returns
     -------
@@ -1695,8 +1694,7 @@ def H_to_iMPS(
         the actual offset in particle number is ``2 * offset``. As such, the
         automatic offset is guaranteed to be even.
     unit_cell_width:
-        Physical length of the chain or cylinder being simulated.
-        Defaults to ``sites_per_cell``.
+        Physical length of the iMPS unit cell. Defaults to ``sites_per_cell``.
 
     Returns
     -------

--- a/src/temfpy/slater.py
+++ b/src/temfpy/slater.py
@@ -1243,7 +1243,7 @@ def C_to_MPS(
         Midpoint of the chain by default.
     spinful:
         Whether to treat the input correlation matrix as describing a
-        spin-rotation symmetric state of spinful fermions or not (``None``),
+        spin-rotation symmetric state of spinful fermions or not (:obj:`None`),
         either with (``"PH"``) or without (``"simple"``) particle-hole
         rotation in the down-spin sector.
     unit_cell_width:
@@ -1412,7 +1412,7 @@ def C_to_iMPS(
         before a warning is raised.
     spinful:
         Whether to treat the input correlation matrices as describing a
-        spin-rotation symmetric state of spinful fermions or not (``None``),
+        spin-rotation symmetric state of spinful fermions or not (:obj:`None`),
         either with (``"PH"``) or without (``"simple"``) particle-hole
         rotation in the down-spin sector.
     offset:
@@ -1591,7 +1591,7 @@ def H_to_MPS(
         Midpoint of the chain by default.
     spinful:
         Whether to treat the input single particle Hamiltonian as describing a
-        spin-rotation symmetric state of spinful fermions or not (``None``),
+        spin-rotation symmetric state of spinful fermions or not (:obj:`None`),
         either with (``"PH"``) or without (``"simple"``) particle-hole
         rotation in the down-spin sector.
     unit_cell_width:
@@ -1680,7 +1680,7 @@ def H_to_iMPS(
         before a warning is raised.
     spinful:
         Whether to treat the input single particle Hamiltonians as describing a
-        spin-rotation symmetric state of spinful fermions or not (``None``),
+        spin-rotation symmetric state of spinful fermions or not (:obj:`None`),
         either with (``"PH"``) or without (``"simple"``) particle-hole
         rotation in the down-spin sector.
     offset:

--- a/src/temfpy/slater.py
+++ b/src/temfpy/slater.py
@@ -1220,6 +1220,7 @@ def C_to_MPS(
     diag_tol: float = _DIAG_TOL,
     ortho_center: int = None,
     spinful: Literal["simple", "PH", None] = None,
+    unit_cell_width: int | None = None,
 ) -> networks.MPS:
     r"""MPS representation of a Slater determinant from its correlation matrix.
 
@@ -1245,6 +1246,11 @@ def C_to_MPS(
         spin-rotation symmetric state of spinful fermions or not (``None``),
         either with (``"PH"``) or without (``"simple"``) particle-hole
         rotation in the down-spin sector.
+    unit_cell_width:
+        Physical length of the chain or cylinder being simulated.
+
+        Defaults to the number of physical sites (i.e. half the number of
+        MPS tensors for nontrivial ``spinful``).
 
     Returns
     -------
@@ -1258,6 +1264,12 @@ def C_to_MPS(
       defaults to 1e-12.
     """
     trunc_par = to_stopping_condition(trunc_par)
+
+    # verify unit_cell_width *before* doubling C
+    if unit_cell_width is None:
+        unit_cell_width = len(C)
+    elif len(C) % unit_cell_width != 0:
+        raise ValueError(f"{unit_cell_width = } does not divide system size {len(C)}")
 
     if spinful == "simple":
         C = spinful_correlation_matrix(C, False)
@@ -1334,7 +1346,9 @@ def C_to_MPS(
         Schmidt = Schmidt_new
 
     form = ["A"] * ortho_center + ["B"] * (L - ortho_center)
-    mps = networks.mps.MPS([fermion_site] * L, tensors, λs, form=form)
+    mps = networks.mps.MPS(
+        [fermion_site] * L, tensors, λs, form=form, unit_cell_width=unit_cell_width
+    )
 
     return mps
 
@@ -1351,6 +1365,7 @@ def C_to_iMPS(
     schmidt_tol: float = iMPS._SCHMIDT_TOL,
     spinful: Literal["simple", "PH", None] = None,
     offset: int | Literal["auto"] = "auto",
+    unit_cell_width: int | None = None,
 ) -> tuple[networks.MPS, iMPS.iMPSError]:
     r"""iMPS representation of a Slater determinant from correlation matrices.
 
@@ -1410,6 +1425,9 @@ def C_to_iMPS(
         If ``spinful == "simple"``, it is interpreted *per spin species*, i.e.,
         the actual offset in particle number is ``2 * offset``. As such, the
         automatic offset is guaranteed to be even.
+    unit_cell_width:
+        Physical length of the chain or cylinder being simulated.
+        Defaults to ``sites_per_cell``.
 
     Returns
     -------
@@ -1429,6 +1447,12 @@ def C_to_iMPS(
       refer to indices in the original correlation matrices.
     """
     trunc_par = to_stopping_condition(trunc_par)
+
+    # verify unit_cell_width *before* doubling C
+    if unit_cell_width is None:
+        unit_cell_width = sites_per_cell
+    elif sites_per_cell % unit_cell_width != 0:
+        raise ValueError(f"{unit_cell_width = } does not divide {sites_per_cell = }")
 
     if spinful == "simple":
         if offset == "auto":  # NB C_short and cut not yet doubled
@@ -1527,7 +1551,12 @@ def C_to_iMPS(
     tensors[0] = npc.tensordot(C, tensors[0], axes=["vR", "vL"])
 
     iMPS_ = networks.MPS(
-        [fermion_site] * sites_per_cell, tensors, λs, bc="infinite", form="B"
+        [fermion_site] * sites_per_cell,
+        tensors,
+        λs,
+        bc="infinite",
+        form="B",
+        unit_cell_width=unit_cell_width,
     )
     error = iMPS.iMPSError(left_unitary, left_schmidt, 0.0, 0.0)
     return iMPS_, error
@@ -1540,6 +1569,7 @@ def H_to_MPS(
     diag_tol: float = _DIAG_TOL,
     ortho_center: int = None,
     spinful: Literal["simple", "PH", None] = None,
+    unit_cell_width: int | None = None,
 ) -> networks.MPS:
     r"""MPS representation of a Slater determinant from its single body Hamiltonian.
 
@@ -1565,6 +1595,11 @@ def H_to_MPS(
         spin-rotation symmetric state of spinful fermions or not (``None``),
         either with (``"PH"``) or without (``"simple"``) particle-hole
         rotation in the down-spin sector.
+    unit_cell_width:
+        Physical length of the chain or cylinder being simulated.
+
+        Defaults to the number of physical sites (i.e. half the number of
+        MPS tensors for nontrivial ``spinful``).
 
     Returns
     -------
@@ -1580,7 +1615,12 @@ def H_to_MPS(
 
     C, _ = correlation_matrix(H)
     return C_to_MPS(
-        C, trunc_par, diag_tol=diag_tol, ortho_center=ortho_center, spinful=spinful
+        C,
+        trunc_par,
+        diag_tol=diag_tol,
+        ortho_center=ortho_center,
+        spinful=spinful,
+        unit_cell_width=unit_cell_width,
     )
 
 
@@ -1596,6 +1636,7 @@ def H_to_iMPS(
     schmidt_tol: float = iMPS._SCHMIDT_TOL,
     spinful: Literal["simple", "PH", None] = None,
     offset: int | Literal["auto"] = "auto",
+    unit_cell_width: int | None = None,
 ) -> tuple[networks.MPS, iMPS.iMPSError]:
     r"""iMPS representation of a Slater determinant from single particle Hamiltonians.
 
@@ -1653,6 +1694,9 @@ def H_to_iMPS(
         If ``spinful == "simple"``, it is interpreted *per spin species*, i.e.,
         the actual offset in particle number is ``2 * offset``. As such, the
         automatic offset is guaranteed to be even.
+    unit_cell_width:
+        Physical length of the chain or cylinder being simulated.
+        Defaults to ``sites_per_cell``.
 
     Returns
     -------
@@ -1684,4 +1728,5 @@ def H_to_iMPS(
         schmidt_tol=schmidt_tol,
         spinful=spinful,
         offset=offset,
+        unit_cell_width=unit_cell_width,
     )

--- a/src/temfpy/testing.py
+++ b/src/temfpy/testing.py
@@ -6,6 +6,7 @@ that determines whether the tests raise :class:`AssertionError`\ s or issue
 :class:`ComparisonWarning`\ s. For speed-critical applications, they may
 also be turned off altogether.
 """
+from typing import Literal
 import warnings
 import numpy as np
 
@@ -13,7 +14,7 @@ from .utils import HT
 
 _DIAG_TOL = 1e-8
 
-TEST_ACTION: str = "warn"
+TEST_ACTION: Literal["raise", "warn", "pass"] = "warn"
 """Determines how the testing functions in this module (and elsewhere in TeMFpy) behave.
 
 Allowed values:
@@ -116,7 +117,7 @@ def check_schmidt_decomposition(modes, C: np.ndarray, diag_tol: float = _DIAG_TO
 
     Parameters
     ----------
-    modes: :class:`slater.SchmidtModes` | :class:`pfaffian.SchmidtModes`
+    modes: :class:`temfpy.slater.SchmidtModes` | :class:`temfpy.pfaffian.SchmidtModes`
         Schmidt modes to check
     C:
         (Nambu) correlation matrix

--- a/src/temfpy/testing.py
+++ b/src/temfpy/testing.py
@@ -41,6 +41,16 @@ class ComparisonWarning(Warning):
     """Generic warning class for failed equality testing or comparison."""
 
 
+def _shape_mismatch(x: np.ndarray, y: np.ndarray, strict: bool = False) -> bool:
+    """Whether the numpy tests find the shapes of x and y to mismatch."""
+    if np.ndim(x) == 0 and np.ndim(y) == 0:  # both are scalars -> :)
+        return False
+    elif np.ndim(x) == 0 or np.ndim(y) == 0:  # one is scalar -> only problem for strict
+        return strict
+    else:  # both are nontrivial arrays, shapes must match exactly
+        return np.shape(x) != np.shape(y)
+
+
 def assert_allclose(
     actual: np.ndarray,
     desired: np.ndarray,
@@ -61,8 +71,11 @@ def assert_allclose(
     AssertionError | ComparisonWarning
         If the shapes of the two arrays don't match or any two entries
         deviate by more than the given tolerance.
+
+        Regardless of :data:`TEST_ACTION`, an :exception:`AssertionError` is
+        raised if the shapes of the two arrays don't match.
     """
-    if TEST_ACTION == "raise":
+    if TEST_ACTION == "raise" or _shape_mismatch(actual, desired, strict):
         np.testing.assert_allclose(
             actual, desired, rtol, atol, equal_nan, err_msg, verbose, strict=strict
         )
@@ -97,8 +110,11 @@ def assert_array_less(
     AssertionError | ComparisonWarning
         If the shapes of the two arrays don't match or any entry of ``x`` is
         not less than the corresponding entry of ``y``.
+
+        Regardless of :data:`TEST_ACTION`, an :exception:`AssertionError` is
+        raised if the shapes of the two arrays don't match.
     """
-    if TEST_ACTION == "raise":
+    if TEST_ACTION == "raise" or _shape_mismatch(x, y, strict):
         np.testing.assert_array_less(x, y, err_msg, verbose, strict=strict)
     elif TEST_ACTION == "warn":
         try:


### PR DESCRIPTION
When constructing the Nambu eigenvectors with eigenvalue 1/2 in `pfaffian`, the check performed on singular values assumed that less than half of the eigenvectors fall into this sector, so we do get 2n_{1/2} singular values. As @kantiger found out, this is not always the case, hence this fix. We always have the right number of 1 singular values, we simply have to cut the number of 0s.

To easier catch such errors in the future, I've also changed the behaviour of the comparison checks in `testing` to always throw an exception if the shapes of the arrays mismatches (according to the stricter broadcasting rules of `np.testing`)

CLOSED since I accidentally created the branch on top of an older dev branch... see #24 for the correct one