### PR TITLE
Fix real eigenvector search in `pfaffian`, stricter tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug fixes
 
 * Gutzwiller projections {func}`temfpy.gutzwiller.abrikosov` and {func}`temfpy.gutzwiller.abrikosov_ph` now handle most infinite fermion MPS correctly. [#18](https://github.com/temfpy/temfpy/pull/18)
+* A check in {method}`temfpy.pfaffian.SchmidtModes.from_correlation_matrix` assumed that at most half of all Nambu eigenvalues are 1/2, which is not always the case. These checks now pass. [#24](https://github.com/temfpy/temfpy/pull/24)
 
 ## TeMFpy 0.2.1 (28 January 2026)
 

--- a/src/temfpy/pfaffian.py
+++ b/src/temfpy/pfaffian.py
@@ -808,7 +808,7 @@ class SchmidtModes:
                 w = np.column_stack((v[:, x0:x1].real, v[:, x0:x1].imag))
                 w, s, _ = svd(w)
 
-                s_exp = [1] * (2 * kh) + [0] * (2 * kh)
+                s_exp = [1] * (2 * kh) + [0] * (s.size - 2 * kh)
                 err = "1/2 eigenvectors cannot be made real"
                 assert_allclose(s, s_exp, rtol=0, atol=diag_tol, err_msg=err)
 

--- a/src/temfpy/testing.py
+++ b/src/temfpy/testing.py
@@ -41,6 +41,16 @@ class ComparisonWarning(Warning):
     """Generic warning class for failed equality testing or comparison."""
 
 
+def _shape_mismatch(x: np.ndarray, y: np.ndarray, strict: bool = False) -> bool:
+    """Whether the numpy tests find the shapes of x and y to mismatch."""
+    if np.ndim(x) == 0 and np.ndim(y) == 0:  # both are scalars -> :)
+        return False
+    elif np.ndim(x) == 0 or np.ndim(y) == 0:  # one is scalar -> only problem for strict
+        return strict
+    else:  # both are nontrivial arrays, shapes must match exactly
+        return np.shape(x) != np.shape(y)
+
+
 def assert_allclose(
     actual: np.ndarray,
     desired: np.ndarray,
@@ -61,8 +71,11 @@ def assert_allclose(
     AssertionError | ComparisonWarning
         If the shapes of the two arrays don't match or any two entries
         deviate by more than the given tolerance.
+
+        Regardless of :data:`TEST_ACTION`, an :exception:`AssertionError` is
+        raised if the shapes of the two arrays don't match.
     """
-    if TEST_ACTION == "raise":
+    if TEST_ACTION == "raise" or _shape_mismatch(actual, desired, strict):
         np.testing.assert_allclose(
             actual, desired, rtol, atol, equal_nan, err_msg, verbose, strict=strict
         )
@@ -97,8 +110,11 @@ def assert_array_less(
     AssertionError | ComparisonWarning
         If the shapes of the two arrays don't match or any entry of ``x`` is
         not less than the corresponding entry of ``y``.
+
+        Regardless of :data:`TEST_ACTION`, an :exception:`AssertionError` is
+        raised if the shapes of the two arrays don't match.
     """
-    if TEST_ACTION == "raise":
+    if TEST_ACTION == "raise" or _shape_mismatch(x, y, strict):
         np.testing.assert_array_less(x, y, err_msg, verbose, strict=strict)
     elif TEST_ACTION == "warn":
         try:


### PR DESCRIPTION
When constructing the Nambu eigenvectors with eigenvalue 1/2 in `pfaffian`, the check performed on singular values assumed that less than half of the eigenvectors fall into this sector, so we do get 2n_{1/2} singular values. As @kantiger found out, this is not always the case, hence this fix. We always have the right number of 1 singular values, we simply have to cut the number of 0s.

To easier catch such errors in the future, I've also changed the behaviour of the comparison checks in `testing` to always throw an exception if the shapes of the arrays mismatches (according to the stricter broadcasting rules of `np.testing`)