### PR TITLE
Fix construction of matching 1/2 eigenvectors in `pfaffian`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Gutzwiller projections {func}`temfpy.gutzwiller.abrikosov` and {func}`temfpy.gutzwiller.abrikosov_ph` now handle most infinite fermion MPS correctly. [#18](https://github.com/temfpy/temfpy/pull/18)
 * A check in {method}`temfpy.pfaffian.SchmidtModes.from_correlation_matrix` assumed that at most half of all Nambu eigenvalues are 1/2, which is not always the case. These checks now pass. [#24](https://github.com/temfpy/temfpy/pull/24)
+* A bug in the construction of Nambu eigenvectors with eigenvalue 1/2 is now fixed. [#25](https://github.com/temfpy/temfpy/pull/25)
 
 ## TeMFpy 0.2.1 (28 January 2026)
 

--- a/src/temfpy/pfaffian.py
+++ b/src/temfpy/pfaffian.py
@@ -874,7 +874,8 @@ class SchmidtModes:
                 # Replace upper half with (Nambu) conjugates of the lower
                 v[:, x:] = v[:, :x].conj()
             elif LR == "R":
-                v[:, x : x + kh] = (v[:, x - kh : x] - 1j * v[:, x : x + kh]) / 2**0.5
+                v[:, x : x + kh] = (-1j * v[:, x - kh : x] + v[:, x : x + kh]) / 2**0.5
+                v[:, x : x + kh] = v[:, x : x + kh][:, ::-1]
                 # Replace lower half with (Nambu) conjugates of the upper
                 v[:, :x] = v[:, x:].conj()
             else:


### PR DESCRIPTION
The recipe in App. B2 of the paper was implemented incorrectly, so left and right 1/2 eigenvectors didn't actually SVD the offdiagonal part of the correlation matrix, thereby invalidating any MPS construction that had 1/2 modes across the central entanglement cut. This is hereby fixed.

