### PR TITLE
Fixing zero-overlap edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Gutzwiller projections {func}`temfpy.gutzwiller.abrikosov` and {func}`temfpy.gutzwiller.abrikosov_ph` now handle most infinite fermion MPS correctly. [#18](https://github.com/temfpy/temfpy/pull/18)
 * A check in {method}`temfpy.pfaffian.SchmidtModes.from_correlation_matrix` assumed that at most half of all Nambu eigenvalues are 1/2, which is not always the case. These checks now pass. [#24](https://github.com/temfpy/temfpy/pull/24)
 * A bug in the construction of Nambu eigenvectors with eigenvalue 1/2 is now fixed. [#25](https://github.com/temfpy/temfpy/pull/25)
+* In certain edge cases involving many 1/2 Nambu-Schmidt eigenvalues, the preference of eigensolvers to return the identity matrix as eigen/singular vectors of the identity matrix resulted in zero overlaps between Boguliubov vacua when constructing {class}`temfpy.pfaffian.MPSTensorData` objects. This issue is mitigated by rotating the real Nambu eigenvectors with eigenvalue 1/2 with a quasi-random orthogonal matrix. This results in a unitary rotation of degenerate Boguliubov-Schmidt states and hence a gauge rotation of the MPS tensors. However, this should have no observable consequences. [#26](https://github.com/temfpy/temfpy/pull/26)
 
 ## TeMFpy 0.2.1 (28 January 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TeMFpy 0.3 (In development)
+## TeMFpy 0.3 (21 July 2026)
 
 ### API breaking changes
 

--- a/src/temfpy/pfaffian.py
+++ b/src/temfpy/pfaffian.py
@@ -43,6 +43,7 @@ from functools import partial
 
 import numpy as np
 from numpy.linalg import eigh, inv, svd
+from scipy.stats import ortho_group
 import tenpy.linalg.np_conserved as npc
 from tenpy import networks
 from pfapack.ctypes import pfaffian as cpf
@@ -863,7 +864,17 @@ class SchmidtModes:
                 vL[:, ixL] = vL[:, ixL] @ U
                 vR[:, ixR] = vR[:, ixR] @ Vh.T
 
-        logger.info(f"{k} Schmidt modes found")
+        # shuffle the basis of 1/2 modes
+        if kh > 0:
+            # quasirandom orthogonal matrix
+            O = ortho_group.rvs(2 * kh, random_state=1234)
+            if vL is not None:
+                vL[:, x - kh : x + kh] = vL[:, x - kh : x + kh] @ O
+            if vR is not None:
+                vR[:, y - kh : y + kh] = vR[:, y - kh : y + kh] @ O
+
+        logger.info(f"2 * {k} entangled Schmidt modes found")
+        logger.debug(f"2 * {kh} Schmidt modes with eigenvalue 1/2")
 
         # Fix Nambu symmetry, convert to complex-fermion basis, compute parity
         def nambu(v, kh, LR):


### PR DESCRIPTION
In certain edge cases involving many 1/2 Nambu-Schmidt eigenvalues, the preference of eigensolvers to return the identity matrix as eigen/singular vectors of the identity matrix resulted in zero overlaps between Boguliubov vacua when constructing `temfpy.pfaffian.MPSTensorData` objects. This issue is mitigated by rotating the real Nambu eigenvectors with eigenvalue 1/2 with a quasi-random orthogonal matrix. This results in a unitary rotation of degenerate Boguliubov-Schmidt states and hence a gauge rotation of the MPS tensors. However, this should have no observable consequences. [#26](https://github.com/temfpy/temfpy/pull/26)