### PR TITLE
Fixing two bugs regarding the offset option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TeMFpy 0.4 (in development)
+
+## TeMFpy 0.3.1 (28 July 2026)
+
+### Bug fixes
+
+* The `offset` parameter is now applied to the gauge-fixing matrix in {func}`temfpy.slater.C_to_iMPS`. [#28](https://github.com/temfpy/temfpy/pull/28)
+
 ## TeMFpy 0.3 (21 July 2026)
 
 ### API breaking changes

--- a/src/examples/iMPS.py
+++ b/src/examples/iMPS.py
@@ -23,7 +23,7 @@ mps_short = slater.H_to_MPS(H_short, trunc_par)
 H_long = H(L_short + 2)
 mps_long = slater.H_to_MPS(H_long, trunc_par)
 
-iMPS, val_metric = iMPS.MPS_to_iMPS(mps_short, mps_long, 2, cut)
+iMPS, val_metric = iMPS.MPS_to_iMPS(mps_short, mps_long, 2, cut, offset=0)
 print("Error metric:", val_metric)
 
 # check overlap after inserting more unit cells

--- a/src/examples/iMPS_slater.py
+++ b/src/examples/iMPS_slater.py
@@ -20,7 +20,7 @@ cut = L_short // 2
 
 H_short = H(L_short)
 H_long = H(L_short + cell)
-iMPS, val_metric = slater.H_to_iMPS(H_short, H_long, trunc_par, 2, cut)
+iMPS, val_metric = slater.H_to_iMPS(H_short, H_long, trunc_par, 2, cut, offset=0)
 print("Error metric:", val_metric)
 
 # check overlap after inserting more unit cells

--- a/src/temfpy/slater.py
+++ b/src/temfpy/slater.py
@@ -1547,6 +1547,10 @@ def C_to_iMPS(
         unitary_tol=unitary_tol,
         schmidt_tol=schmidt_tol,
     )
+    # subtract offset != 0 from virtual legs
+    if offset != 0:
+        C.get_leg("vL").charges -= offset
+        C.get_leg("vR").charges -= offset
     tensors[0] = npc.tensordot(C, tensors[0], axes=["vR", "vL"])
 
     iMPS_ = networks.MPS(


### PR DESCRIPTION
## Fixed
- **[Critical]** `slater.C_to_imps`: offset was not applied to the gauge-fixing matrix `C`.
- **[Minor]** All iMPS Slater examples crashed because the new `offset` option was not set (regression).

@attila-i-szabo I would like to push this directly as a new version since the first is a breaking bug