### PR TITLE
Fixed a bug in gutzwiller.py for infinite MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## TeMFpy 0.4 (in development)
 
+## TeMFpy 0.3.2 (29 July 2026)
+
+### Bug fixes
+
+* Fixed an error in {func}`temfpy.gutzwiller.abrikosov` and {func}`temfpy.gutzwiller.abrikosov_ph` for infinite MPS when `return_canonical=True` by preventing an unsupported `cutoff` argument and resolving the correct canonical form via boundary conditions. [#29](https://github.com/temfpy/temfpy/pull/29)
+
 ## TeMFpy 0.3.1 (28 July 2026)
 
 ### Bug fixes

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -153,6 +153,7 @@ def abrikosov(
 
         - no symmetry quantum numbers other than fermion number or parity can be handled.
         - only ``'finite'`` and ``'infinite'`` boundary conditions are supported.
+        - For infinite MPS, ``return_canonical`` triggers :meth:`~tenpy.networks.mps.MPS.canonical_form_infinite1`.
     """
 
     assert (
@@ -254,7 +255,13 @@ def abrikosov(
 
     if return_canonical:
         # Transform into right canoncial form
-        mps.canonical_form(cutoff=cutoff)
+        match mps.bc:
+            case "finite":
+                mps.canonical_form_finite(cutoff=cutoff)
+            case "infinite":
+                mps.canonical_form_infinite1()
+            case _:
+                raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
         logger.info("Transformed MPS to right canonical form")
     else:
         warn(
@@ -307,7 +314,7 @@ def abrikosov_ph(
     return_canonical:
         Whether to transform the output MPS to right canonical form.
     cutoff:
-        Cutoff for Schmidt values to keep in the canonical form.
+        Cutoff for Schmidt values to keep in the canonical form. Only used for finite MPS.
     parity:
         For infinite MPS **only**, determines which fermion parity sector
         of the virtual legs to keep in the projected iMPS.
@@ -334,6 +341,7 @@ def abrikosov_ph(
 
         - no symmetry quantum numbers other than fermion number or parity can be handled.
         - only ``'finite'`` and ``'infinite'`` boundary conditions are supported.
+        - For infinite MPS, ``return_canonical`` triggers :meth:`~tenpy.networks.mps.MPS.canonical_form_infinite1`.
     """
 
     assert (
@@ -445,7 +453,13 @@ def abrikosov_ph(
 
     if return_canonical:
         # Transform into right canoncial form
-        mps.canonical_form(cutoff=cutoff)
+        match mps.bc:
+            case "finite":
+                mps.canonical_form_finite(cutoff=cutoff)
+            case "infinite":
+                mps.canonical_form_infinite1()
+            case _:
+                raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
         logger.info("Transformed MPS to right canonical form")
     else:
         warn(

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -341,7 +341,6 @@ def abrikosov_ph(
 
         - no symmetry quantum numbers other than fermion number or parity can be handled.
         - only ``'finite'`` and ``'infinite'`` boundary conditions are supported.
-        - For infinite MPS, ``return_canonical`` triggers :meth:`~tenpy.networks.mps.MPS.canonical_form_infinite1`.
     """
 
     assert (

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -153,7 +153,6 @@ def abrikosov(
 
         - no symmetry quantum numbers other than fermion number or parity can be handled.
         - only ``'finite'`` and ``'infinite'`` boundary conditions are supported.
-        - For infinite MPS, ``return_canonical`` triggers :meth:`~tenpy.networks.mps.MPS.canonical_form_infinite1`.
     """
 
     assert (

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -128,7 +128,7 @@ def abrikosov(
     return_canonical:
         Whether to transform the output MPS to right canonical form.
     cutoff:
-        Cutoff for Schmidt values to keep in the canonical form.
+        Cutoff for Schmidt values to keep in the canonical form. Only used for finite MPS.
     q_left:
         For infinite MPS **only**, determines which fermion number/parity sector
         of the leftmost virtual leg to keep.


### PR DESCRIPTION
### Fix: Prevent invalid `cutoff` argument in infinite MPS canonicalization

When `return_canonical=True`, `abrikosov` and `abrikosov_ph` previously called `mps.canonical_form` with a `cutoff` argument. For infinite MPS, this triggered `mps.canonical_form_infinite1`, which does not accept `cutoff`, causing an error. 

The implementation now checks the MPS boundary condition and calls the correct canonical form function with the supported arguments.

@attila-i-szabo Since this is a critical bug, I suggest we cut a new release for this.