### PR TITLE
Added trivial schmidt values after gutzwiller projecting.

### DIFF
--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -248,11 +248,14 @@ def abrikosov(
     mps.sites = [spin_site] * mps.L
 
     mps.form = [None] * mps.L
+
     # TODO: Tenpy at the moment requires the schmidt vectors to be non trivial to determine 
-    # TODO: the bond dimensions. As soon as this is fixed, change this back to
-    # TODO: mps._S = [None] * (mps.L + 1)
-    legs = [mps._B[0].get_leg("vL")] + [B.get_leg("vR") for B in mps._B]
-    mps._S = [np.eye(leg.ind_len) for leg in legs]
+    # TODO: the bond dimensions. As soon as this is fixed, change this to
+    # TODO: mps._S = [None] * (mps.L + 1) if mps.finite else [None] * mps.L
+    legs = [B.get_leg("vL") for B in mps._B]
+    if mps.finite: 
+        legs += [mps._B[-1].get_leg("vR")]
+    mps._S = [np.ones(leg.ind_len)/np.sqrt(leg.ind_len) for leg in legs]
 
     logger.info("Completed projection to spin-1/2 space. No conserved charges left.")
 
@@ -446,12 +449,13 @@ def abrikosov_ph(
     mps.sites = [spin_site] * mps.L
 
     mps.form = [None] * mps.L
-
     # TODO: Tenpy at the moment requires the schmidt vectors to be non trivial to determine 
-    # TODO: the bond dimensions. As soon as this is fixed, change this back to
-    # TODO: mps._S = [None] * (mps.L + 1)
-    legs = [mps._B[0].get_leg("vL")] + [B.get_leg("vR") for B in mps._B]
-    mps._S = [np.eye(leg.ind_len) for leg in legs]
+    # TODO: the bond dimensions. As soon as this is fixed, change this to
+    # TODO: mps._S = [None] * (mps.L + 1) if mps.finite else [None] * mps.L
+    legs = [B.get_leg("vL") for B in mps._B]
+    if mps.finite:
+        legs += [mps._B[-1].get_leg("vR")]
+    mps._S = [np.ones(leg.ind_len)/np.sqrt(leg.ind_len) for leg in legs]
     
     logger.info(
         "Completed projection to spin-1/2 space. Conserved charge is now %s",

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -248,7 +248,11 @@ def abrikosov(
     mps.sites = [spin_site] * mps.L
 
     mps.form = [None] * mps.L
-    mps._S = [None] * (mps.L + 1 if mps.finite else mps.L)
+    # TODO: Tenpy at the moment requires the schmidt vectors to be non trivial to determine 
+    # TODO: the bond dimensions. As soon as this is fixed, change this back to
+    # TODO: mps._S = [None] * (mps.L + 1)
+    legs = [mps._B[0].get_leg("vL")] + [B.get_leg("vR") for B in mps._B]
+    mps._S = [np.eye(leg.ind_len) for leg in legs]
 
     logger.info("Completed projection to spin-1/2 space. No conserved charges left.")
 
@@ -442,8 +446,13 @@ def abrikosov_ph(
     mps.sites = [spin_site] * mps.L
 
     mps.form = [None] * mps.L
-    mps._S = [None] * (mps.L + 1)
 
+    # TODO: Tenpy at the moment requires the schmidt vectors to be non trivial to determine 
+    # TODO: the bond dimensions. As soon as this is fixed, change this back to
+    # TODO: mps._S = [None] * (mps.L + 1)
+    legs = [mps._B[0].get_leg("vL")] + [B.get_leg("vR") for B in mps._B]
+    mps._S = [np.eye(leg.ind_len) for leg in legs]
+    
     logger.info(
         "Completed projection to spin-1/2 space. Conserved charge is now %s",
         conserved_spin,

--- a/src/temfpy/gutzwiller.py
+++ b/src/temfpy/gutzwiller.py
@@ -249,13 +249,13 @@ def abrikosov(
 
     mps.form = [None] * mps.L
 
-    # TODO: Tenpy at the moment requires the schmidt vectors to be non trivial to determine 
+    # TODO: Tenpy at the moment requires the schmidt vectors to be non trivial to determine
     # TODO: the bond dimensions. As soon as this is fixed, change this to
     # TODO: mps._S = [None] * (mps.L + 1) if mps.finite else [None] * mps.L
     legs = [B.get_leg("vL") for B in mps._B]
-    if mps.finite: 
+    if mps.finite:
         legs += [mps._B[-1].get_leg("vR")]
-    mps._S = [np.ones(leg.ind_len)/np.sqrt(leg.ind_len) for leg in legs]
+    mps._S = [np.ones(leg.ind_len) / np.sqrt(leg.ind_len) for leg in legs]
 
     logger.info("Completed projection to spin-1/2 space. No conserved charges left.")
 
@@ -267,7 +267,9 @@ def abrikosov(
             case "infinite":
                 mps.canonical_form_infinite1()
             case _:
-                raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
+                raise NotImplementedError(
+                    f"Boundary condition {mps.bc!r} not supported"
+                )
         logger.info("Transformed MPS to right canonical form")
     else:
         warn(
@@ -449,14 +451,14 @@ def abrikosov_ph(
     mps.sites = [spin_site] * mps.L
 
     mps.form = [None] * mps.L
-    # TODO: Tenpy at the moment requires the schmidt vectors to be non trivial to determine 
+    # TODO: Tenpy at the moment requires the schmidt vectors to be non trivial to determine
     # TODO: the bond dimensions. As soon as this is fixed, change this to
     # TODO: mps._S = [None] * (mps.L + 1) if mps.finite else [None] * mps.L
     legs = [B.get_leg("vL") for B in mps._B]
     if mps.finite:
         legs += [mps._B[-1].get_leg("vR")]
-    mps._S = [np.ones(leg.ind_len)/np.sqrt(leg.ind_len) for leg in legs]
-    
+    mps._S = [np.ones(leg.ind_len) / np.sqrt(leg.ind_len) for leg in legs]
+
     logger.info(
         "Completed projection to spin-1/2 space. Conserved charge is now %s",
         conserved_spin,
@@ -470,7 +472,9 @@ def abrikosov_ph(
             case "infinite":
                 mps.canonical_form_infinite1()
             case _:
-                raise NotImplementedError(f"Boundary condition {mps.bc!r} not supported")
+                raise NotImplementedError(
+                    f"Boundary condition {mps.bc!r} not supported"
+                )
         logger.info("Transformed MPS to right canonical form")
     else:
         warn(


### PR DESCRIPTION
### BUG

- TeNPy relies on Schmidt values to determine bond dimensions, causing `mps.canonical_form_infinite` to crash for non-canonical MPS when Schmidt values are `None`. Until TeNPy fixes this, `gutzwiller` circumvents the bug by setting trivial Schmidt values of the correct shape.