### PR TITLE
correlation matrices can now be complex for offset auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## TeMFpy 0.4 (in development)
 
+### Bug fixes
+
+* Gutzwiller projection routines now correctly keep the effect of non-inplace {class}`~tenpy.linalg.np_conserved.Array` operations such as {meth}`~tenpy.linalg.np_conserved.Array.drop_charge` and {meth}`~tenpy.linalg.np_conserved.Array.gauge_total_charge`. [#30](https://github.com/temfpy/temfpy/pull/30)
+* Gutzwiller projection routines add a complete set of dummy Schmidt values for compatibility with {meth}`~tenpy.networks.mps.MPS.canonical_form_infinite1` in TeNPy v1.1.0. [#31](https://github.com/temfpy/temfpy/pull/31)
+* Fix a bug preventing {func}`temfpy.slater.C_to_iMPS` to be used with complex correlation matrices. [#32](https://github.com/temfpy/temfpy/pull/32)
+
 ## TeMFpy 0.3.2 (29 July 2026)
 
 ### Bug fixes

--- a/src/temfpy/slater.py
+++ b/src/temfpy/slater.py
@@ -1455,7 +1455,7 @@ def C_to_iMPS(
 
     if spinful == "simple":
         if offset == "auto":  # NB C_short and cut not yet doubled
-            offset = 2 * round(np.trace(C_short[:cut, :cut]))
+            offset = 2 * round(np.trace(C_short[:cut, :cut]).real)
             logger.info(f"Using total offset {offset} for conserved fermion number")
         else:
             offset *= 2


### PR DESCRIPTION
## Bug
When `offset = "auto"`, `slater.C_to_iMPS()` calculates and rounds the trace of `C`. If `C` is a complex matrix, the trace evaluates to a complex number (even with a zero imaginary part), causing `round()` to fail as it is undefined for complex types. This is fixed by extracting the real part of the trace before applying the rounding operation.