### PR TITLE
Remove unnecessary `setflags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Gutzwiller projection routines now correctly keep the effect of non-inplace {class}`~tenpy.linalg.np_conserved.Array` operations such as {meth}`~tenpy.linalg.np_conserved.Array.drop_charge` and {meth}`~tenpy.linalg.np_conserved.Array.gauge_total_charge`. [#30](https://github.com/temfpy/temfpy/pull/30)
 * Gutzwiller projection routines add a complete set of dummy Schmidt values for compatibility with {meth}`~tenpy.networks.mps.MPS.canonical_form_infinite1` in TeNPy v1.1.0. [#31](https://github.com/temfpy/temfpy/pull/31)
 * Fix a bug preventing {func}`temfpy.slater.C_to_iMPS` to be used with complex correlation matrices. [#32](https://github.com/temfpy/temfpy/pull/32)
+* Removed unnecessary and erroneous {meth}`~numpy.ndarray.setflags` calls from {meth}`temfpy.pfaffian.MPSTensorData.from_schmidt_vectors`. [#33](https://github.com/temfpy/temfpy/pull/33)
 
 ## TeMFpy 0.3.2 (29 July 2026)
 

--- a/src/temfpy/pfaffian.py
+++ b/src/temfpy/pfaffian.py
@@ -1695,8 +1695,8 @@ class MPSTensorData:
         elif len(v_bra) == len(v_ket):
             # copy v_bra and sets_bra if parity fix needed
             if Schmidt_bra.parity(mode) % 2 != Schmidt_ket.parity(mode) % 2:
-                v_bra = v_bra.copy().setflags(write=True)
-                sets_bra = sets_bra.copy().setflags(write=True)
+                v_bra = v_bra.copy()
+                sets_bra = sets_bra.copy()
         else:
             raise ValueError(
                 f"{mode.capitalize()} sides `Schmidt_bra` and `Schmidt_ket` must match\n"


### PR DESCRIPTION
Originally I planned to make all `ndarray` fields in the various objects write protected so as to prevent accidentally overwriting them. This never happened, and the only place where it was remembered is two `setflags` operations in `pfaffian.MPSTensorData.from_schmidt_vectors()`, which also messed up the result if their code path were called. Instead of putting out the write protection everywhere (which would also go against users' usual expectation of numpy), we simply drop these now.
