### PR TITLE
updated version of gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
           with:
             name: dist-ubuntu-latest
             path: dist/
-        - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
           with:
             repository-url: https://test.pypi.org/legacy/
             verbose: true
@@ -94,7 +94,7 @@ jobs:
     needs: [build_package]
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: pypiss
       url: https://pypi.org/project/temfpy/
     permissions:
       contents: read
@@ -104,6 +104,6 @@ jobs:
         with:
           name: dist-ubuntu-latest
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           verbose: true


### PR DESCRIPTION
Bump `pypa/gh-action-pypi-publish` from v1.13.0 to v1.14.2 in both the TestPyPI and PyPI publish workflows.
Adds support for uploading distributions with core metadata v2.5, fixing the failing publish workflows.